### PR TITLE
fix(discovery): batch D1 queries to stay within subrequest cap

### DIFF
--- a/src/lib/discovery/discovery.test.ts
+++ b/src/lib/discovery/discovery.test.ts
@@ -60,6 +60,30 @@ function makeDeps(overrides: Partial<DiscoveryDeps> = {}): DiscoveryDeps {
 	};
 }
 
+// Wraps a D1Database and counts every prepare() — each prepared statement in
+// this codebase is executed exactly once, so the count tracks D1 subrequests,
+// the resource bounded by the Workers per-invocation cap (issue #63).
+interface CountingD1 extends D1Database {
+	readonly statementCount: number;
+}
+
+function countingD1Proxy(db: D1Database): CountingD1 {
+	let count = 0;
+	return new Proxy(db, {
+		get(target, prop, receiver) {
+			if (prop === "statementCount") return count;
+			if (prop === "prepare") {
+				return (query: string) => {
+					count++;
+					return target.prepare(query);
+				};
+			}
+			const value = Reflect.get(target, prop, receiver);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as unknown as CountingD1;
+}
+
 // -- tests --
 
 describe("discovery: createSerpApiSearch", () => {
@@ -737,5 +761,75 @@ describe("discovery: runDiscovery", () => {
 
 		expect(reportedStats).not.toBeNull();
 		expect(reportedStats).toEqual(stats);
+	});
+
+	it("stays within a bounded number of D1 statements regardless of result volume (#63)", async () => {
+		// A big locality can yield hundreds of unique results. If resolution +
+		// slug lookups run per result (2–4 D1 calls each) the run blows the
+		// Workers subrequest cap and persists nothing. Pin the design property:
+		// non-insert D1 work must be O(distinct cities + slug chunks), not
+		// O(results). The only term allowed to scale with volume is the
+		// INSERT chunking floor (ceil(N / BATCH_SIZE)).
+		const VOLUME = 200;
+		const results = Array.from({ length: VOLUME }, (_, i) =>
+			fakeResult({
+				place_id: `place_vol_${i}`,
+				title: `Firma Numer ${i}`,
+				address: "ul. Testowa 1, Kraków",
+				gps_coordinates: { latitude: 50.0647, longitude: 19.945 },
+			}),
+		);
+		const counted = countingD1Proxy(env.leadgen);
+		const deps = makeDeps({ db: counted, searchApi: staticSearch(results) });
+
+		await runDiscovery(deps);
+
+		// All rows persisted (nothing dropped by an aborted run).
+		const row = await env.leadgen
+			.prepare(
+				"SELECT COUNT(*) AS cnt FROM businesses WHERE place_id LIKE 'place_vol_%'",
+			)
+			.first<{ cnt: number }>();
+		expect(row?.cnt).toBe(VOLUME);
+
+		// Budget = the irreducible INSERT floor (200 rows / BATCH_SIZE 4 = 50
+		// statements) + a small overhead that must stay *sublinear* in result
+		// volume: resolution memoized to O(distinct cities), slug collisions to
+		// O(distinctBases / chunk) batched lookups, plus a few bookkeeping
+		// queries. Measured today: 59 (50 inserts + 5 slug chunks + 4 fixed).
+		// The pre-fix per-result path issued 453. Any surviving per-result DB
+		// call would add >= VOLUME (200) statements, so this threshold catches
+		// a regression while tolerating slug-chunk-size tuning.
+		const INSERT_FLOOR = Math.ceil(VOLUME / 4);
+		expect(counted.statementCount).toBeLessThan(INSERT_FLOOR + 20);
+	});
+
+	it("a 1,500-result locality completes within the Workers subrequest cap (#63)", async () => {
+		// The biggest cities come first in the locality queue, so a run must
+		// survive the worst realistic volume without blowing the 1000-subrequest
+		// cap (D1 calls count). Statement count is bounded by ceil(N/BATCH_SIZE)
+		// inserts + sublinear resolution/slug work, not the 2–4×N of the bug.
+		const VOLUME = 1500;
+		const SUBREQUEST_CAP = 1000;
+		const results = Array.from({ length: VOLUME }, (_, i) =>
+			fakeResult({
+				place_id: `place_big_${i}`,
+				title: `Wielki Biznes ${i}`,
+				address: "ul. Testowa 1, Kraków",
+				gps_coordinates: { latitude: 50.0647, longitude: 19.945 },
+			}),
+		);
+		const counted = countingD1Proxy(env.leadgen);
+		const deps = makeDeps({ db: counted, searchApi: staticSearch(results) });
+
+		await runDiscovery(deps);
+
+		const row = await env.leadgen
+			.prepare(
+				"SELECT COUNT(*) AS cnt FROM businesses WHERE place_id LIKE 'place_big_%'",
+			)
+			.first<{ cnt: number }>();
+		expect(row?.cnt).toBe(VOLUME);
+		expect(counted.statementCount).toBeLessThan(SUBREQUEST_CAP);
 	});
 });

--- a/src/lib/discovery/index.ts
+++ b/src/lib/discovery/index.ts
@@ -237,11 +237,12 @@ export async function runDiscovery(
 		if (!locality) break;
 
 		const seen = new Set<string>();
-		const businesses: BusinessInsert[] = [];
-		// Tracks slugs already reserved in this run, per locality, so duplicates
-		// within the current batch get -2/-3/... suffixes instead of silently
-		// colliding on the DB UNIQUE(slug, locality_id) via INSERT OR IGNORE.
-		const reservedSlugs = new Map<number, Set<string>>();
+		// Collect raw results across all categories first, then resolve
+		// localities + assign slugs in one batched pass. Doing that DB work per
+		// result (2–4 queries each) can blow the Workers subrequest cap on a
+		// large locality and abort the whole run after the SerpAPI spend (#63).
+		const rawResults: Array<{ result: SerpApiLocalResult; category: string }> =
+			[];
 		let apiCalls = 0;
 
 		for (const category of categories) {
@@ -252,28 +253,7 @@ export async function runDiscovery(
 				for (const r of results) {
 					if (seen.has(r.place_id)) continue;
 					seen.add(r.place_id);
-
-					const resolved = await resolveLocality(
-						db,
-						r.address ?? null,
-						r.gps_coordinates.latitude,
-						r.gps_coordinates.longitude,
-					);
-					const localityId = resolved?.id ?? locality.id;
-					let reserved = reservedSlugs.get(localityId);
-					if (!reserved) {
-						reserved = new Set<string>();
-						reservedSlugs.set(localityId, reserved);
-					}
-					const slug = await generateUniqueSlug(
-						r.title,
-						localityId,
-						db,
-						reserved,
-					);
-					reserved.add(slug);
-
-					businesses.push(toBusiness(r, slug, localityId, category));
+					rawResults.push({ result: r, category });
 				}
 			} catch (err) {
 				if (err instanceof SerpApiError) {
@@ -292,6 +272,7 @@ export async function runDiscovery(
 			}
 		}
 
+		const businesses = await buildBusinesses(db, locality.id, rawResults);
 		await batchInsert(db, businesses);
 		if (!hardStop) await markSearched(db, locality.id);
 
@@ -486,6 +467,92 @@ async function resolveLocality(
 	return null;
 }
 
+// Memoize resolution by parsed city (falling back to a GPS bucket when the
+// address has no city). A single discovery run is geographically focused on one
+// town, so results collapse to a handful of distinct keys — turning O(results)
+// locality queries into O(distinct cities). When several results share a city
+// the first one's coordinates settle any same-name disambiguation for the rest.
+async function resolveLocalityCached(
+	db: D1Database,
+	cache: Map<string, number>,
+	address: string | null,
+	lat: number | null,
+	lng: number | null,
+	fallbackLocalityId: number,
+): Promise<number> {
+	const city = parseCityFromAddress(address);
+	const key = city
+		? `n:${city.toLowerCase()}`
+		: lat != null && lng != null
+			? `g:${lat.toFixed(2)}:${lng.toFixed(2)}`
+			: "null";
+	const cached = cache.get(key);
+	if (cached !== undefined) return cached;
+	const match = await resolveLocality(db, address, lat, lng);
+	const localityId = match?.id ?? fallbackLocalityId;
+	cache.set(key, localityId);
+	return localityId;
+}
+
+// Turn raw scraped results into insert rows: resolve each result's locality
+// (memoized), then assign collision-free slugs per locality group with one
+// batched lookup instead of a query per result (#63).
+async function buildBusinesses(
+	db: D1Database,
+	fallbackLocalityId: number,
+	rawResults: Array<{ result: SerpApiLocalResult; category: string }>,
+): Promise<BusinessInsert[]> {
+	const resolveCache = new Map<string, number>();
+	const prepared: Array<{
+		result: SerpApiLocalResult;
+		category: string;
+		localityId: number;
+		base: string;
+	}> = [];
+	for (const { result, category } of rawResults) {
+		const localityId = await resolveLocalityCached(
+			db,
+			resolveCache,
+			result.address ?? null,
+			result.gps_coordinates.latitude,
+			result.gps_coordinates.longitude,
+			fallbackLocalityId,
+		);
+		prepared.push({
+			result,
+			category,
+			localityId,
+			base: businessSlugBase(result.title),
+		});
+	}
+
+	const byLocality = new Map<number, typeof prepared>();
+	for (const item of prepared) {
+		const group = byLocality.get(item.localityId);
+		if (group) group.push(item);
+		else byLocality.set(item.localityId, [item]);
+	}
+
+	const businesses: BusinessInsert[] = [];
+	for (const [localityId, group] of byLocality) {
+		const existing = await fetchExistingSlugs(
+			db,
+			localityId,
+			group.map((i) => i.base),
+		);
+		// Slugs handed out within this batch, so intra-run duplicates get
+		// -2/-3/… suffixes instead of silently colliding on the DB
+		// UNIQUE(slug, locality_id) via INSERT OR IGNORE.
+		const reserved = new Set<string>();
+		for (const item of group) {
+			const slug = assignSlug(item.base, existing, reserved);
+			reserved.add(slug);
+			businesses.push(toBusiness(item.result, slug, localityId, item.category));
+		}
+	}
+	return businesses;
+}
+
 // -- internal: slug --
 
 const MAX_SLUG_ATTEMPTS = 50;
@@ -498,34 +565,55 @@ function businessSlugBase(title: string): string {
 	return base || "firma";
 }
 
-async function generateUniqueSlug(
-	title: string,
-	localityId: number,
+// 45 bases × 2 range bounds + 1 locality = 91, under the D1 100-param-per-
+// statement cap. Chunk distinct bases so one locality needs only
+// ceil(distinctBases / 45) collision lookups instead of one query per result.
+const SLUG_BASE_CHUNK = 45;
+
+// Fetch every existing slug in this locality that could collide with one of the
+// desired bases — the base itself or any "base-N" suffix. Uses a range match
+// rather than LIKE: a base and its "base-N" suffixes all sort into
+// [base, base + "."), since "-" (0x2D) is the lowest slug char and "." (0x2E)
+// sits just above it (slugs are [a-z0-9-] under BINARY collation). LIKE would
+// trip D1's low LIKE-pattern-length cap on long scraped titles (#24).
+async function fetchExistingSlugs(
 	db: D1Database,
-	reserved: ReadonlySet<string> = new Set(),
-): Promise<string> {
-	const base = businessSlugBase(title);
-	const candidates = [
-		base,
-		...Array.from({ length: MAX_SLUG_ATTEMPTS }, (_, i) => `${base}-${i + 2}`),
-	];
-	const placeholders = candidates.map(() => "?").join(", ");
-	const { results } = await db
-		.prepare(
-			`SELECT slug FROM businesses WHERE locality_id = ? AND slug IN (${placeholders}) ORDER BY slug`,
-		)
-		.bind(localityId, ...candidates)
-		.all<{ slug: string }>();
-	const existing = new Set(results.map((r) => r.slug));
-	for (const slug of reserved) existing.add(slug);
-	if (!existing.has(base)) return base;
+	localityId: number,
+	bases: string[],
+): Promise<Set<string>> {
+	const distinct = [...new Set(bases)];
+	const existing = new Set<string>();
+	for (let i = 0; i < distinct.length; i += SLUG_BASE_CHUNK) {
+		const chunk = distinct.slice(i, i + SLUG_BASE_CHUNK);
+		const conds = chunk.map(() => "(slug >= ? AND slug < ?)").join(" OR ");
+		const params: string[] = [];
+		for (const base of chunk) params.push(base, `${base}.`);
+		const { results } = await db
+			.prepare(
+				`SELECT slug FROM businesses WHERE locality_id = ? AND (${conds})`,
+			)
+			.bind(localityId, ...params)
+			.all<{ slug: string }>();
+		for (const r of results) existing.add(r.slug);
+	}
+	return existing;
+}
+
+// Pick the first free slug for `base`: the base, else base-2, base-3, …, using
+// slugs already in the DB (`existing`) and those handed out earlier in this
+// batch (`reserved`). Mirrors the previous per-row suffixing behaviour.
+function assignSlug(
+	base: string,
+	existing: ReadonlySet<string>,
+	reserved: ReadonlySet<string>,
+): string {
+	const taken = (slug: string) => existing.has(slug) || reserved.has(slug);
+	if (!taken(base)) return base;
 	for (let suffix = 2; suffix <= MAX_SLUG_ATTEMPTS + 1; suffix++) {
 		const candidate = `${base}-${suffix}`;
-		if (!existing.has(candidate)) return candidate;
+		if (!taken(candidate)) return candidate;
 	}
-	throw new Error(
-		`slug collision limit exceeded: ${base} in locality ${localityId}`,
-	);
+	throw new Error(`slug collision limit exceeded: ${base}`);
 }
 
 // -- internal: DB helpers --


### PR DESCRIPTION
## Problem

Discovery resolved localities and generated slugs **per scraped result** (2–4 D1 queries each inside the result loop). A large locality (18 categories × up to 5 pages × ~20 results → 500–1500 unique places) could issue 1,000–6,000 D1 calls in one invocation, exceeding the Workers 1,000-subrequest cap. When the cap hit, `batchInsert` threw uncaught → `runDiscovery` aborted → `failRun`. Net effect: SerpAPI budget burned, **zero rows persisted**, `markSearched` never ran, so the same oversized city was retried daily forever.

Fixes #63.

## Fix

Collect all results first, then do the DB work in a batched pass:

- **`resolveLocalityCached`** — memoizes locality resolution by parsed city (GPS-bucket fallback). O(results) → O(distinct cities), ~1 per run.
- **`fetchExistingSlugs`** — one batched slug-collision lookup per locality group (chunked to stay under the 100-param cap) instead of a query per result. Uses a **range match** (`slug >= base AND slug < base||'.'`) rather than `LIKE`, because D1 enforces a low `SQLITE_MAX_LIKE_PATTERN_LENGTH` that a long scraped title's `LIKE 'base-%'` pattern trips (the existing "very long titles" test caught this).
- **`assignSlug`** — pure in-memory suffixing, preserving exact `-2/-3` collision behavior.
- INSERT chunking left unchanged (BATCH_SIZE 4, 84 params/statement).

## Results

| Volume | Before | After |
|--------|--------|-------|
| 200 results | 453 D1 statements | **59** (50 inserts + 5 slug chunks + 4 bookkeeping) |
| 1,500 results | 1,000–6,000 (aborts) | well under the 1,000 cap |

## Test plan

- New: query-budget test pins a bounded D1 statement count for 200 results (documented budget, catches any per-result regression).
- New: 1,500-result locality test asserts all rows persist and statements stay under the subrequest cap.
- `pnpm test` → 427 passed (54 files), incl. 27 discovery tests.
- `pnpm build`, `pnpm lint:ci`, `pnpm types` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)