### PR TITLE
fix(cron): geocoder fallback, per-run lead count, funnel tie-break (#64)

### DIFF
--- a/src/lib/discovery/discovery.test.ts
+++ b/src/lib/discovery/discovery.test.ts
@@ -531,6 +531,37 @@ describe("discovery: runDiscovery", () => {
 		expect(row?.searched_at).not.toBeNull();
 	});
 
+	it("counts only leads inserted by this run, not pre-existing same-day leads", async () => {
+		// A prior run today already produced a lead-shaped business (phone, no
+		// website). A second same-day run (e.g. manual POST /run-cron/discovery)
+		// must not attribute that earlier lead to itself.
+		await env.leadgen
+			.prepare(
+				"INSERT INTO businesses (locality_id, place_id, title, slug, phone, website, category, gps_lat, gps_lng, site_status) VALUES (?, ?, ?, ?, ?, NULL, ?, 0, 0, 'pending')",
+			)
+			.bind(
+				TEST_IDS.localities.krakow,
+				"place_prior_lead",
+				"Prior Lead",
+				"prior-lead",
+				"+48500500500",
+				"firma",
+			)
+			.run();
+
+		// This run scrapes only a non-lead (has a website).
+		const nonLead = fakeResult({
+			place_id: "place_run_nonlead",
+			phone: undefined,
+			website: "https://example.com",
+		});
+		const deps = makeDeps({ searchApi: staticSearch([nonLead]) });
+
+		const stats = await runDiscovery(deps);
+
+		expect(stats.totalNewLeads).toBe(0);
+	});
+
 	it("multi-locality retry: 0 leads in first locality → tries next", async () => {
 		// Push existing businesses to yesterday so countTodayLeads starts at 0
 		await env.leadgen

--- a/src/lib/discovery/index.ts
+++ b/src/lib/discovery/index.ts
@@ -232,6 +232,11 @@ export async function runDiscovery(
 	let errorKind: DiscoveryErrorKind | null = null;
 	let hardStop = false;
 
+	// Baseline the max business id so newLeads counts only rows inserted by THIS
+	// run — a same-day second run (e.g. manual /run-cron/discovery) must not
+	// inherit the morning run's leads via a global daily count.
+	const baselineBusinessId = await maxBusinessId(db);
+
 	for (let attempt = 0; attempt < MAX_LOCALITY_ATTEMPTS; attempt++) {
 		const locality = await getNextLocality(db);
 		if (!locality) break;
@@ -276,7 +281,7 @@ export async function runDiscovery(
 		await batchInsert(db, businesses);
 		if (!hardStop) await markSearched(db, locality.id);
 
-		const newLeads = await countTodayLeads(db);
+		const newLeads = await countNewLeads(db, baselineBusinessId);
 		totalApiCalls += apiCalls;
 		localityStats.push({
 			name: locality.name,
@@ -626,11 +631,23 @@ async function getNextLocality(db: D1Database): Promise<Locality | null> {
 		.first<Locality>();
 }
 
-async function countTodayLeads(db: D1Database): Promise<number> {
+async function maxBusinessId(db: D1Database): Promise<number> {
+	const r = await db
+		.prepare("SELECT MAX(id) as m FROM businesses")
+		.first<{ m: number | null }>();
+	return r?.m ?? 0;
+}
+
+// Leads inserted after `sinceId` — i.e. by the current run only. Since the
+// locality loop breaks on the first locality with newLeads > 0, and this count
+// is monotonic across localities, the run's single non-zero locality reports
+// exactly the leads it inserted.
+async function countNewLeads(db: D1Database, sinceId: number): Promise<number> {
 	const r = await db
 		.prepare(
-			"SELECT COUNT(*) as cnt FROM businesses WHERE website IS NULL AND phone IS NOT NULL AND created_at >= date('now')",
+			"SELECT COUNT(*) as cnt FROM businesses WHERE id > ? AND website IS NULL AND phone IS NOT NULL",
 		)
+		.bind(sinceId)
 		.first<{ cnt: number }>();
 	return r?.cnt ?? 0;
 }

--- a/src/lib/funnel.test.ts
+++ b/src/lib/funnel.test.ts
@@ -39,6 +39,34 @@ describe("getFunnelStats", () => {
 		expect(Object.keys(stats.counts)).toHaveLength(7);
 	});
 
+	it("tie-breaks same-second statuses by id — latest insert wins", async () => {
+		const db = env.leadgen;
+		const sellerId = TEST_IDS.sellers.jan;
+		await db.prepare("DELETE FROM call_log").run();
+
+		// Two statuses tapped within the same second (call_log.created_at has
+		// second precision). "called" first, then "interested" (higher id).
+		const ts = "2026-01-01 12:00:00";
+		await db
+			.prepare(
+				"INSERT INTO call_log (business_id, seller_id, status, created_at) VALUES (?, ?, ?, ?)",
+			)
+			.bind(1, sellerId, "called", ts)
+			.run();
+		await db
+			.prepare(
+				"INSERT INTO call_log (business_id, seller_id, status, created_at) VALUES (?, ?, ?, ?)",
+			)
+			.bind(1, sellerId, "interested", ts)
+			.run();
+
+		const stats = await getFunnelStats(db, sellerId);
+
+		expect(stats.total).toBe(1);
+		expect(stats.counts.interested).toBe(1);
+		expect(stats.counts.called).toBe(0);
+	});
+
 	it("returns zero counts for seller with no call_log entries", async () => {
 		// Insert a seller with no call_log
 		await env.leadgen
@@ -123,6 +151,34 @@ describe("getWeekOverWeekDelta", () => {
 		expect(delta.interested).toBe(1);
 		expect(delta.deal_closed).toBe(1);
 		expect(delta.pending).toBe(0);
+	});
+
+	it("tie-breaks same-second statuses by id within the week window", async () => {
+		const db = env.leadgen;
+		const sellerId = TEST_IDS.sellers.jan;
+		await db.prepare("DELETE FROM call_log").run();
+
+		// Identical timestamp inside the current week for both rows.
+		const { t: ts } = (await db
+			.prepare("SELECT datetime('now', '-1 hours') AS t")
+			.first<{ t: string }>()) as { t: string };
+		await db
+			.prepare(
+				"INSERT INTO call_log (business_id, seller_id, status, created_at) VALUES (?, ?, ?, ?)",
+			)
+			.bind(1, sellerId, "called", ts)
+			.run();
+		await db
+			.prepare(
+				"INSERT INTO call_log (business_id, seller_id, status, created_at) VALUES (?, ?, ?, ?)",
+			)
+			.bind(1, sellerId, "interested", ts)
+			.run();
+
+		const delta = await getWeekOverWeekDelta(db, sellerId);
+
+		expect(delta.interested).toBe(1);
+		expect(delta.called).toBe(0);
 	});
 });
 

--- a/src/lib/funnel.ts
+++ b/src/lib/funnel.ts
@@ -28,7 +28,7 @@ export async function getFunnelStats(
 			`SELECT status, COUNT(*) as cnt
        FROM (
          SELECT status,
-           ROW_NUMBER() OVER (PARTITION BY business_id ORDER BY created_at DESC) as rn
+           ROW_NUMBER() OVER (PARTITION BY business_id ORDER BY created_at DESC, id DESC) as rn
          FROM call_log WHERE seller_id = ?
        ) WHERE rn = 1
        GROUP BY status`,
@@ -68,7 +68,7 @@ async function getWeekCounts(
 			`SELECT status, COUNT(*) as cnt
        FROM (
          SELECT status,
-           ROW_NUMBER() OVER (PARTITION BY business_id ORDER BY created_at DESC) as rn
+           ROW_NUMBER() OVER (PARTITION BY business_id ORDER BY created_at DESC, id DESC) as rn
          FROM call_log
          WHERE seller_id = ?
            AND created_at >= datetime('now', ? || ' days')

--- a/src/lib/geocoder.test.ts
+++ b/src/lib/geocoder.test.ts
@@ -1,10 +1,11 @@
 import { env } from "cloudflare:workers";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetDb } from "../../test/seed";
 import {
 	type GeocoderDeps,
 	type GeoResult,
 	geocodeLocalities,
+	nominatimWithFallback,
 } from "./geocoder";
 
 function successGeo(overrides: Partial<GeoResult> = {}): GeoResult {
@@ -185,5 +186,35 @@ describe("geocodeLocalities", () => {
 
 		expect(result.processed).toBe(0);
 		expect(result.failed).toBe(1);
+	});
+});
+
+describe("nominatimWithFallback", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("treats a fallback 429 as rate-limited, not 'not found' — no backoff penalty", async () => {
+		// Primary returns no result → the shorter fallback query fires ~1.1s later,
+		// right when Nominatim's 1 req/s policy is most likely to 429 us. A 429 must
+		// stop the run (mirroring the primary), NOT ratchet the locality's backoff.
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("[]", { status: 200 }))
+			.mockResolvedValueOnce(new Response("", { status: 429 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		// id=4 (Nowa Wieś) has lat=NULL → the only eligible locality.
+		await geocodeLocalities(makeDeps({ geocode: nominatimWithFallback }));
+
+		const row = await env.leadgen
+			.prepare(
+				"SELECT geocode_fail_count, geocode_retry_after FROM localities WHERE id = 4",
+			)
+			.first<{
+				geocode_fail_count: number;
+				geocode_retry_after: string | null;
+			}>();
+
+		expect(row?.geocode_fail_count).toBe(0);
+		expect(row?.geocode_retry_after).toBeNull();
 	});
 });

--- a/src/lib/geocoder.ts
+++ b/src/lib/geocoder.ts
@@ -88,7 +88,7 @@ async function nominatimGeocode(loc: LocalityRow): Promise<GeoResult | null> {
 	};
 }
 
-async function nominatimWithFallback(
+export async function nominatimWithFallback(
 	loc: LocalityRow,
 ): Promise<GeoResult | null> {
 	const primary = await nominatimGeocode(loc);
@@ -100,7 +100,10 @@ async function nominatimWithFallback(
 	const q = `${loc.name}, ${loc.woj_name}, Polska`;
 	const url = `${NOMINATIM_URL}?${new URLSearchParams({ q, format: "json", limit: "1" })}`;
 	const res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
-	if (!res.ok) return null;
+	// Mirror the primary: a rate-limit / server error must stop the run, not be
+	// recorded as "not found" (which ratchets the locality's backoff to 7 days).
+	if (res.status === 429) throw new Error("RATE_LIMITED");
+	if (!res.ok) throw new Error(`HTTP_${res.status}`);
 
 	const data = (await res.json()) as NominatimResult[];
 	if (!data.length) return null;


### PR DESCRIPTION
Three small, independently-tested correctness fixes in the cron pipeline (issue #64), each driven RED→GREEN.

## Fixes

1. **Geocoder fallback ate transient 429/5xx** (`src/lib/geocoder.ts`) — the fallback Nominatim call did `if (!res.ok) return null`, so a rate-limit fired ~1.1s after the primary (against Nominatim's 1 req/s policy) was recorded as "not found", ratcheting `geocode_fail_count` and the backoff toward the 7-day cap. Now mirrors the primary: `429 → throw RATE_LIMITED`, other non-OK → `throw HTTP_<status>`, so the run stops without penalizing the locality.

2. **`countTodayLeads` was a global daily count** (`src/lib/discovery/index.ts`) — a same-day second run (e.g. manual `POST /api/admin/run-cron/discovery`) saw the morning run's leads after its first locality, broke immediately, and attributed them to itself. Now captures a `MAX(id)` baseline before the loop and counts only `id > baseline AND website IS NULL AND phone IS NOT NULL` (+1 D1 statement/run — stays within the #63 subrequest budget).

3. **Funnel "latest status" tie-broke nondeterministically within one second** (`src/lib/funnel.ts`) — `call_log.created_at` has second precision, so "called" then "interested" tapped within a second tied and SQLite picked arbitrarily. Now `ORDER BY created_at DESC, id DESC` in both window functions.

## Verification

- `pnpm test`: **431/431 pass** (incl. the #63 subrequest-cap tests, sensitive to added D1 statements)
- `pnpm build`: clean
- `pnpm lint:ci` (Biome): clean; `astro check`: 0 errors across 145 files
- New failing-first tests: `geocoder.test.ts` (fallback 429 → no backoff), `discovery.test.ts` (per-run lead count), `funnel.test.ts` (two tie-break tests, both window functions)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)