### PR TITLE
fix(content): format operating_hours instead of rendering raw JSON blob

### DIFF
--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,4 +1,5 @@
 import type { SiteData } from "../types/site";
+import { formatOperatingHours } from "./operating-hours";
 import { getSite } from "./site-store";
 import { escapeHtml, sendMessage } from "./telegram";
 
@@ -560,7 +561,9 @@ async function loadChatContext(
 				title: cleanText(business.title),
 				category: cleanText(business.category),
 				address: cleanNullableText(business.address),
-				openingHours: cleanNullableText(business.operating_hours),
+				openingHours: cleanNullableText(
+					formatOperatingHours(business.operating_hours).display,
+				),
 				description: cleanNullableText(business.description),
 				rating: business.rating,
 				reviewsCount: business.reviews_count,

--- a/src/lib/discovery/discovery.test.ts
+++ b/src/lib/discovery/discovery.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { resetDb, TEST_IDS } from "../../../test/seed";
 import type { Locality } from "../../types/business";
 import type { SerpApiLocalResult } from "../../types/serpapi";
+import { formatOperatingHours } from "../operating-hours";
 import { SerpApiError } from "./errors";
-import { createSerpApiSearch, runDiscovery } from "./index";
+import { createSerpApiSearch, runDiscovery, toBusiness } from "./index";
 import type { DiscoveryDeps, NotifyPort, SearchPort, StatePort } from "./ports";
 import { SKIP_FLAG_KEY } from "./preflight";
 
@@ -862,5 +863,33 @@ describe("discovery: runDiscovery", () => {
 			.first<{ cnt: number }>();
 		expect(row?.cnt).toBe(VOLUME);
 		expect(counted.statementCount).toBeLessThan(SUBREQUEST_CAP);
+	});
+});
+
+describe("discovery: toBusiness operating_hours round-trip", () => {
+	// Guards the contract between how discovery serializes operating_hours and
+	// how formatOperatingHours parses it — if toBusiness's shape drifts, the
+	// public page / JSON-LD would silently regress to a raw blob again (#66).
+	it("serializes hours in a shape formatOperatingHours can render", () => {
+		const result = fakeResult({
+			operating_hours: {
+				monday: "9 AM to 5 PM",
+				tuesday: "9 AM to 5 PM",
+			},
+		});
+
+		const business = toBusiness(result, "test-biznes", 1, "restauracja");
+		const { display, schema } = formatOperatingHours(business.operating_hours);
+
+		expect(business.operating_hours).not.toBeNull();
+		expect(display).not.toMatch(/^\{/);
+		expect(display).toContain("poniedziałek");
+		expect(schema).toEqual(["Mo-Tu 09:00-17:00"]);
+	});
+
+	it("stores null when a scraped result has no operating hours", () => {
+		const business = toBusiness(fakeResult(), "test-biznes", 1, "restauracja");
+		expect(business.operating_hours).toBeNull();
+		expect(formatOperatingHours(business.operating_hours).display).toBeNull();
 	});
 });

--- a/src/lib/discovery/index.ts
+++ b/src/lib/discovery/index.ts
@@ -659,7 +659,9 @@ async function markSearched(db: D1Database, localityId: number): Promise<void> {
 		.run();
 }
 
-function toBusiness(
+// Exported for the operating-hours round-trip guard (#66): the shape this
+// serializes operating_hours into must stay parseable by formatOperatingHours.
+export function toBusiness(
 	r: SerpApiLocalResult,
 	slug: string,
 	localityId: number,

--- a/src/lib/operating-hours.test.ts
+++ b/src/lib/operating-hours.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { formatOperatingHours } from "./operating-hours";
+
+describe("formatOperatingHours", () => {
+	it("converts a scraped JSON blob into a Polish display string", () => {
+		const raw = JSON.stringify({
+			monday: "9 AM to 5 PM",
+			tuesday: "9 AM to 5 PM",
+		});
+
+		const { display } = formatOperatingHours(raw);
+
+		expect(display).not.toMatch(/^\{/);
+		expect(display).toContain("poniedziałek");
+		expect(display).toContain("09:00");
+		expect(display).toContain("17:00");
+	});
+
+	it("collapses consecutive identical days in week order and marks closed days", () => {
+		const raw = JSON.stringify({
+			// deliberately out of week order to prove canonical sorting
+			sunday: "Closed",
+			saturday: "10 AM to 2 PM",
+			friday: "9 AM to 5 PM",
+			monday: "9 AM to 5 PM",
+			tuesday: "9 AM to 5 PM",
+			wednesday: "9 AM to 5 PM",
+			thursday: "9 AM to 5 PM",
+		});
+
+		const { display } = formatOperatingHours(raw);
+
+		expect(display).toBe(
+			"poniedziałek–piątek 09:00–17:00, sobota 10:00–14:00, niedziela nieczynne",
+		);
+	});
+
+	it("emits schema.org openingHours entries with closed days omitted", () => {
+		const raw = JSON.stringify({
+			monday: "9 AM to 5 PM",
+			tuesday: "9 AM to 5 PM",
+			wednesday: "9 AM to 5 PM",
+			thursday: "9 AM to 5 PM",
+			friday: "9 AM to 5 PM",
+			saturday: "10 AM to 2 PM",
+			sunday: "Closed",
+		});
+
+		const { schema } = formatOperatingHours(raw);
+
+		expect(schema).toEqual(["Mo-Fr 09:00-17:00", "Sa 10:00-14:00"]);
+		for (const entry of schema) {
+			expect(entry).toMatch(
+				/^[A-Z][a-z](-[A-Z][a-z])? \d{2}:\d{2}-\d{2}:\d{2}$/,
+			);
+		}
+	});
+
+	it("renders round-the-clock days instead of dropping them", () => {
+		const raw = JSON.stringify({
+			monday: "Open 24 hours",
+			tuesday: "Open 24 hours",
+		});
+
+		const { display, schema } = formatOperatingHours(raw);
+
+		expect(display).toBe("poniedziałek–wtorek całodobowo");
+		expect(schema).toEqual(["Mo-Tu 00:00-23:59"]);
+	});
+
+	it("passes legacy human-readable strings through unchanged as display", () => {
+		const { display, schema } = formatOperatingHours("Pon-Pt 09:00-17:00");
+
+		expect(display).toBe("Pon-Pt 09:00-17:00");
+		expect(schema).toEqual([]);
+	});
+
+	it("returns no hours for null or empty input", () => {
+		expect(formatOperatingHours(null)).toEqual({ display: null, schema: [] });
+		expect(formatOperatingHours(undefined)).toEqual({
+			display: null,
+			schema: [],
+		});
+		expect(formatOperatingHours("")).toEqual({ display: null, schema: [] });
+	});
+
+	it("degrades to no display rather than printing an unparseable JSON blob", () => {
+		const raw = JSON.stringify({
+			monday: "whenever we feel like it",
+			tuesday: "¯\\_(ツ)_/¯",
+		});
+
+		const { display, schema } = formatOperatingHours(raw);
+
+		expect(display).toBeNull();
+		expect(schema).toEqual([]);
+	});
+});

--- a/src/lib/operating-hours.ts
+++ b/src/lib/operating-hours.ts
@@ -1,0 +1,115 @@
+export interface FormattedOperatingHours {
+	/** Human-readable Polish display string, or null when there is nothing to show. */
+	display: string | null;
+	/** schema.org `openingHours` entries like "Mo-Fr 09:00-17:00"; empty when unparseable. */
+	schema: string[];
+}
+
+// Canonical week order. `pl` is the public-page label, `abbr` the schema.org
+// two-letter day code (Mo, Tu, …). Order matters: consecutive days with
+// identical hours are collapsed into a range.
+const WEEK: ReadonlyArray<{ key: string; pl: string; abbr: string }> = [
+	{ key: "monday", pl: "poniedziałek", abbr: "Mo" },
+	{ key: "tuesday", pl: "wtorek", abbr: "Tu" },
+	{ key: "wednesday", pl: "środa", abbr: "We" },
+	{ key: "thursday", pl: "czwartek", abbr: "Th" },
+	{ key: "friday", pl: "piątek", abbr: "Fr" },
+	{ key: "saturday", pl: "sobota", abbr: "Sa" },
+	{ key: "sunday", pl: "niedziela", abbr: "Su" },
+];
+
+const CLOSED = "nieczynne";
+
+// Parse "9 AM to 5 PM" / "9:30 AM–5 PM" style time tokens into 24h "HH:MM".
+function parseTime(token: string): string | null {
+	const match = token.trim().match(/^(\d{1,2})(?::(\d{2}))?\s*(AM|PM)$/i);
+	if (!match) return null;
+	let hour = Number(match[1]);
+	const minute = match[2] ? Number(match[2]) : 0;
+	const meridiem = match[3].toUpperCase();
+	if (hour < 1 || hour > 12 || minute > 59) return null;
+	if (meridiem === "AM") hour = hour === 12 ? 0 : hour;
+	else hour = hour === 12 ? 12 : hour + 12;
+	return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+// A day's hours resolved into its public-page label and, when applicable, a
+// schema.org time range (null for closed days, which schema.org can't express).
+interface DayValue {
+	display: string;
+	schema: string | null;
+}
+
+// Normalize a single day's raw hours string, or return null when the text can't
+// be understood (that day is then skipped rather than printed verbatim).
+function normalizeDay(hours: string): DayValue | null {
+	if (/closed|zamkni|nieczynne/i.test(hours)) {
+		return { display: CLOSED, schema: null };
+	}
+	if (/24\s*hours|całą\s*dobę|całodobow/i.test(hours)) {
+		return { display: "całodobowo", schema: "00:00-23:59" };
+	}
+	const normalized = hours.replace(/\s+to\s+/i, "–").replace(/[-—]/g, "–");
+	const [rawStart, rawEnd] = normalized.split("–");
+	if (!rawStart || !rawEnd) return null;
+	const start = parseTime(rawStart);
+	const end = parseTime(rawEnd);
+	if (!start || !end) return null;
+	return { display: `${start}–${end}`, schema: `${start}-${end}` };
+}
+
+export function formatOperatingHours(
+	raw: string | null | undefined,
+): FormattedOperatingHours {
+	if (!raw) return { display: null, schema: [] };
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return { display: raw, schema: [] };
+	}
+	if (typeof parsed !== "object" || parsed === null) {
+		return { display: raw, schema: [] };
+	}
+
+	const source = parsed as Record<string, unknown>;
+	const byDay = new Map<string, DayValue>();
+	for (const day of WEEK) {
+		const value = source[day.key];
+		if (typeof value !== "string") continue;
+		const normalized = normalizeDay(value);
+		if (normalized) byDay.set(day.key, normalized);
+	}
+
+	// Collapse consecutive days sharing the same schedule into groups, then
+	// render the display string and schema.org array from the same groups.
+	const display: string[] = [];
+	const schema: string[] = [];
+	for (let i = 0; i < WEEK.length; ) {
+		const value = byDay.get(WEEK[i].key);
+		if (value === undefined) {
+			i++;
+			continue;
+		}
+		let j = i;
+		while (
+			j + 1 < WEEK.length &&
+			byDay.get(WEEK[j + 1].key)?.display === value.display
+		) {
+			j++;
+		}
+
+		const plRange = i === j ? WEEK[i].pl : `${WEEK[i].pl}–${WEEK[j].pl}`;
+		display.push(`${plRange} ${value.display}`);
+
+		if (value.schema) {
+			const abbrRange =
+				i === j ? WEEK[i].abbr : `${WEEK[i].abbr}-${WEEK[j].abbr}`;
+			schema.push(`${abbrRange} ${value.schema}`);
+		}
+		i = j + 1;
+	}
+
+	return { display: display.length ? display.join(", ") : null, schema };
+}

--- a/src/lib/public-page.test.ts
+++ b/src/lib/public-page.test.ts
@@ -70,6 +70,23 @@ describe("buildPublicBusinessPageModel", () => {
 		expect(model.chat.privacyNotice).toBe(ASSISTANT_PRIVACY_NOTICE);
 	});
 
+	it("renders operating hours as human-readable Polish text, not a JSON blob", () => {
+		// The exact shape toBusiness() persists: JSON.stringify of a
+		// Record<string, string> keyed by lowercase English day names.
+		const scrapedHours = JSON.stringify({
+			monday: "9 AM to 5 PM",
+			tuesday: "9 AM to 5 PM",
+		});
+		const model = buildPublicBusinessPageModel(site, {
+			...biz,
+			operating_hours: scrapedHours,
+		});
+
+		expect(model.location.openingHours).not.toMatch(/^\{/);
+		expect(model.location.openingHours).toContain("poniedziałek");
+		expect(model.location.openingHours).toContain("09:00");
+	});
+
 	it("builds public SEO metadata without direct contact details", () => {
 		// Assumptions for issue #48:
 		// Input SEO text may contain direct phone, email, or contact URL generated before contact suppression.

--- a/src/lib/public-page.ts
+++ b/src/lib/public-page.ts
@@ -1,4 +1,5 @@
 import type { SiteData, SiteService } from "../types/site";
+import { formatOperatingHours } from "./operating-hours";
 import type { BizData } from "./structured-data";
 
 export const ASSISTANT_CTA_LABEL = "Zapytaj asystenta";
@@ -94,7 +95,7 @@ export function buildPublicBusinessPageModel(
 		},
 		location: {
 			address: site.contact.address,
-			openingHours: biz?.operating_hours ?? null,
+			openingHours: formatOperatingHours(biz?.operating_hours).display,
 			mapHref: buildMapHref(biz),
 		},
 		chat: {

--- a/src/lib/structured-data.test.ts
+++ b/src/lib/structured-data.test.ts
@@ -15,15 +15,24 @@ const baseBiz: BizData = {
 	gps_lng: 21.1100277,
 	rating: 4.7,
 	reviews_count: 98,
-	operating_hours: "Pon-Pt 09:00-17:00",
+	// The real persisted shape: JSON.stringify of the scraped
+	// Record<string, string> keyed by lowercase English day names.
+	operating_hours: JSON.stringify({
+		monday: "9 AM to 5 PM",
+		tuesday: "9 AM to 5 PM",
+		wednesday: "9 AM to 5 PM",
+		thursday: "9 AM to 5 PM",
+		friday: "9 AM to 5 PM",
+		saturday: "10 AM to 2 PM",
+		sunday: "Closed",
+	}),
 };
 
 describe("buildLocalBusinessLd", () => {
 	// Assumptions for issue #44:
 	// Input is the current business row shape used by generated pages.
 	// Output is LocalBusiness JSON-LD with no direct contact fields exposed.
-	// This iteration does not test full schema.org normalization of opening hours.
-	it("omits direct contact fields while preserving address and opening hours", () => {
+	it("omits direct contact fields and emits schema.org-format opening hours", () => {
 		const ld = buildLocalBusinessLd(
 			baseBiz,
 			"https://wizytowka.link/zabki/bistro",
@@ -37,7 +46,20 @@ describe("buildLocalBusinessLd", () => {
 			streetAddress: baseBiz.address,
 			addressCountry: "PL",
 		});
-		expect(ld.openingHours).toBe(baseBiz.operating_hours);
+		expect(ld.openingHours).toEqual(["Mo-Fr 09:00-17:00", "Sa 10:00-14:00"]);
+		for (const entry of ld.openingHours as string[]) {
+			expect(entry).toMatch(
+				/^[A-Z][a-z](-[A-Z][a-z])? \d{2}:\d{2}-\d{2}:\d{2}$/,
+			);
+		}
+	});
+
+	it("omits openingHours entirely for unparseable input", () => {
+		const ld = buildLocalBusinessLd(
+			{ ...baseBiz, operating_hours: "call us maybe" },
+			"https://wizytowka.link/zabki/bistro",
+		);
+		expect(ld).not.toHaveProperty("openingHours");
 	});
 
 	it("includes ratingCount when both rating and reviews_count present", () => {

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,3 +1,5 @@
+import { formatOperatingHours } from "./operating-hours";
+
 export interface BizData {
 	title: string;
 	phone: string;
@@ -15,6 +17,7 @@ export function safeJsonScript(value: unknown): string {
 }
 
 export function buildLocalBusinessLd(biz: BizData, _url: string) {
+	const openingHours = formatOperatingHours(biz.operating_hours).schema;
 	return {
 		"@context": "https://schema.org",
 		"@type": "LocalBusiness",
@@ -24,7 +27,7 @@ export function buildLocalBusinessLd(biz: BizData, _url: string) {
 			streetAddress: biz.address,
 			addressCountry: "PL",
 		},
-		...(biz.operating_hours ? { openingHours: biz.operating_hours } : {}),
+		...(openingHours.length ? { openingHours } : {}),
 		geo: {
 			"@type": "GeoCoordinates",
 			latitude: biz.gps_lat,

--- a/src/pages/api/chat/messages.test.ts
+++ b/src/pages/api/chat/messages.test.ts
@@ -382,6 +382,38 @@ describe("POST /api/chat/messages", () => {
 		expect(requestText).not.toContain("https://example.test/source");
 	});
 
+	it("sends human-readable operating hours to the LLM, not a raw JSON blob", async () => {
+		await env.leadgen
+			.prepare(
+				`UPDATE businesses
+         SET operating_hours = ?
+         WHERE slug = 'hydraulik-warszawa'`,
+			)
+			.bind(JSON.stringify({ monday: "9 AM to 5 PM", tuesday: "9 AM to 5 PM" }))
+			.run();
+		await putSite(
+			env.sites,
+			"live",
+			"warszawa",
+			"hydraulik-warszawa",
+			sampleSite,
+		);
+		const fetchMock = mockZaiFetch("Godziny są dostępne na stronie.");
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+		const sessionId = await activeSessionId();
+
+		await POST({
+			request: chatMessageRequest({
+				sessionId,
+				content: "Jakie są godziny?",
+			}),
+		} as Parameters<typeof POST>[0]);
+
+		const requestText = JSON.stringify(zaiRequestBody(fetchMock));
+		expect(requestText).not.toContain('{\\"monday\\"');
+		expect(requestText).toContain("poniedziałek");
+	});
+
 	it("preserves previous turns in a two-message visitor conversation", async () => {
 		const fetchMock = mockZaiFetchSequence([
 			"Adres to ul. Marszałkowska 1.",


### PR DESCRIPTION
## Problem

`operating_hours` was persisted as `JSON.stringify(Record<string,string>)` and used verbatim in three places — so any business scraped with hours showed a raw blob on its public page (`Godziny otwarcia: {"monday":"9 AM to 5 PM",…}`), sent the same blob to the GLM-5 assistant, and emitted invalid schema.org `openingHours` in JSON-LD (breaking Google Rich Results). This is live, user-visible corruption on the pages shown to owners as the sales pitch.

## Fix

New deep module `src/lib/operating-hours.ts` — `formatOperatingHours(raw)` → `{ display, schema }`:

- Parses the scraped blob, maps English day keys → Polish, converts 12h → 24h, collapses consecutive identical days.
- `display`: e.g. `poniedziałek–piątek 09:00–17:00, sobota 10:00–14:00, niedziela nieczynne`.
- `schema`: schema.org array, e.g. `["Mo-Fr 09:00-17:00", "Sa 10:00-14:00"]`.
- Handles closed (`nieczynne`) and round-the-clock (`całodobowo` / `00:00-23:59`) days.
- Legacy plain strings pass through unchanged; unparseable input degrades to omitting the field rather than printing a blob.

Wired into `public-page.ts` (display), `structured-data.ts` (schema array, omitted when empty), and `chat.ts` (assistant context). The three layouts needed no change — they interpolate the now-formatted string.

## Regression guard

`toBusiness()` is exported and a round-trip test feeds its real output through `formatOperatingHours`, so discovery-serialization drift can't silently reintroduce the blob.

## Acceptance criteria

- [x] Pages and JSON-LD show formatted hours; unparseable input omits the field instead of printing a blob
- [x] Round-trip test from `toBusiness()` output shape exists
- [x] `pnpm test` (452 passed) and `pnpm build` pass; Biome + `astro check` clean

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)