### PR TITLE
feat(seo): link category pages from locality index and business layouts (#71)

### DIFF
--- a/src/components/layouts/CenteredLayout.astro
+++ b/src/components/layouts/CenteredLayout.astro
@@ -4,6 +4,7 @@ import type { PublicBusinessPageModel } from '../../lib/public-page';
 import AuditmosFooterLink from '../AuditmosFooterLink.astro';
 import AssistantChat from '../AssistantChat.astro';
 import CategoryLogo from '../CategoryLogo.astro';
+import { slugify } from '../../lib/slug';
 
 interface RelatedBusiness {
   title: string;
@@ -33,6 +34,15 @@ const { site, page, category, slug, locSlug, locName, locLabel, relatedBusinesse
       <h1 class="hero-title">{site.hero.headline}</h1>
       <p class="hero-sub text-hero-accent">{site.hero.subheadline}</p>
       <p class="text-sm opacity-80 mt-2">{locLabel}</p>
+      {category && (
+        <a
+          href={`/${locSlug}/kategoria/${slugify(category)}`}
+          class="mt-3 inline-flex items-center gap-1 text-sm underline underline-offset-4 opacity-80 transition-opacity hover:opacity-100"
+        >
+          <span aria-hidden="true">←</span>
+          Więcej firm z kategorii „{category}”
+        </a>
+      )}
       <span class="hero-divider" aria-hidden="true"></span>
     </div>
   </section>

--- a/src/components/layouts/MinimalLayout.astro
+++ b/src/components/layouts/MinimalLayout.astro
@@ -4,6 +4,7 @@ import type { PublicBusinessPageModel } from '../../lib/public-page';
 import AuditmosFooterLink from '../AuditmosFooterLink.astro';
 import AssistantChat from '../AssistantChat.astro';
 import CategoryLogo from '../CategoryLogo.astro';
+import { slugify } from '../../lib/slug';
 
 interface RelatedBusiness {
   title: string;
@@ -35,6 +36,15 @@ const { site, page, category, slug, locSlug, locName, locLabel, relatedBusinesse
       </div>
       <p class="hero-sub text-muted-foreground">{site.hero.subheadline}</p>
       <p class="text-sm text-muted-foreground mt-2">{locLabel}</p>
+      {category && (
+        <a
+          href={`/${locSlug}/kategoria/${slugify(category)}`}
+          class="mt-3 inline-flex items-center gap-1 text-sm text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+        >
+          <span aria-hidden="true">←</span>
+          Więcej firm z kategorii „{category}”
+        </a>
+      )}
       <span class="hero-divider !mx-0" aria-hidden="true"></span>
     </div>
   </section>

--- a/src/components/layouts/SplitLayout.astro
+++ b/src/components/layouts/SplitLayout.astro
@@ -4,6 +4,7 @@ import type { PublicBusinessPageModel } from '../../lib/public-page';
 import AuditmosFooterLink from '../AuditmosFooterLink.astro';
 import AssistantChat from '../AssistantChat.astro';
 import CategoryLogo from '../CategoryLogo.astro';
+import { slugify } from '../../lib/slug';
 
 interface RelatedBusiness {
   title: string;
@@ -33,6 +34,15 @@ const { site, page, category, slug, locSlug, locName, locLabel, relatedBusinesse
         <h1 class="hero-title">{site.hero.headline}</h1>
         <p class="hero-sub text-hero-accent">{site.hero.subheadline}</p>
         <p class="text-sm opacity-80 mt-2">{locLabel}</p>
+        {category && (
+          <a
+            href={`/${locSlug}/kategoria/${slugify(category)}`}
+            class="mt-3 inline-flex items-center gap-1 text-sm underline underline-offset-4 opacity-80 transition-opacity hover:opacity-100"
+          >
+            <span aria-hidden="true">←</span>
+            Więcej firm z kategorii „{category}”
+          </a>
+        )}
         <span class="hero-divider !mx-0" aria-hidden="true"></span>
       </div>
       <div class="md:w-1/3 flex flex-col items-center md:items-end gap-6">

--- a/src/components/layouts/category-backlink.test.ts
+++ b/src/components/layouts/category-backlink.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import centered from "./CenteredLayout.astro?raw";
+import minimal from "./MinimalLayout.astro?raw";
+import split from "./SplitLayout.astro?raw";
+
+const layouts = [
+	["CenteredLayout", centered],
+	["SplitLayout", split],
+	["MinimalLayout", minimal],
+] as const;
+
+describe("business page layout category backlink", () => {
+	// Issue #71: business pages were dead-ends toward their category page — no
+	// layout linked back to /[loc]/kategoria/[category]. Every layout must emit a
+	// backlink so the category pages accrue internal links from every business,
+	// and the href must slugify the raw category so it resolves to the route.
+	for (const [name, source] of layouts) {
+		it(`${name} links back to the category page`, () => {
+			expect(source).toContain("/kategoria/");
+			expect(source).toContain("slugify(category)");
+		});
+	}
+});

--- a/src/lib/category.test.ts
+++ b/src/lib/category.test.ts
@@ -120,4 +120,23 @@ describe("findLocalityCategories", () => {
 		const result = await findLocalityCategories(env.leadgen, "wroclaw");
 		expect(result).toEqual([]);
 	});
+
+	it("surfaces slugs that resolve to non-empty category pages (issue #71 no-orphan contract)", async () => {
+		// The locality index renders one link per category using cat.slug.
+		// Each of those hrefs must resolve back through findCategoryBusinesses to
+		// a real, non-empty category page — otherwise the links are orphans again.
+		// Guards against slug drift between the link builder and the route lookup.
+		const categories = await findLocalityCategories(env.leadgen, "warszawa");
+		expect(categories.length).toBeGreaterThan(0);
+
+		for (const cat of categories) {
+			const page = await findCategoryBusinesses(
+				env.leadgen,
+				"warszawa",
+				cat.slug,
+			);
+			expect(page).not.toBeNull();
+			expect(page?.businesses.length).toBeGreaterThan(0);
+		}
+	});
 });

--- a/src/pages/[loc]/index.astro
+++ b/src/pages/[loc]/index.astro
@@ -3,6 +3,7 @@ import '../../styles/base.css';
 import { env } from 'cloudflare:workers';
 import AuditmosFooterLink from '../../components/AuditmosFooterLink.astro';
 import type { LocalityRow, BusinessRow } from '../../types/business';
+import { findLocalityCategories } from '../../lib/category';
 import { pluralizeFirma } from '../../lib/pluralize';
 import { safeJsonScript } from '../../lib/structured-data';
 
@@ -25,6 +26,8 @@ const { results: businesses } = await db
   )
   .bind(locality.id)
   .all<BusinessRow>();
+
+const categories = await findLocalityCategories(db, loc);
 
 const url = `https://wizytowka.link/${loc}`;
 const title = `Firmy w ${locality.name} — wizytowka.link`;
@@ -130,6 +133,27 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=3600, s-maxage=8640
             : `${businesses.length} ${pluralizeFirma(businesses.length)} w katalogu`}
         </p>
       </div>
+
+      {categories.length > 0 && (
+        <nav aria-label="Kategorie" class="mb-8">
+          <h2 class="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">
+            Przeglądaj według kategorii
+          </h2>
+          <ul class="flex flex-wrap gap-2">
+            {categories.map((cat) => (
+              <li>
+                <a
+                  href={`/${loc}/kategoria/${cat.slug}`}
+                  class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:border-blue-200 hover:text-blue-600"
+                >
+                  {cat.categoryName}
+                  <span class="text-xs text-gray-400">{cat.count}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
 
       {businesses.length > 0 ? (
         <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/pages/[loc]/index.test.ts
+++ b/src/pages/[loc]/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import source from "./index.astro?raw";
+
+describe("locality index category navigation", () => {
+	// Issue #71: category pages were orphans — findLocalityCategories had zero
+	// production callers and no page emitted a /kategoria/ href, so those pages
+	// were reachable only from the sitemap. The locality index must surface
+	// category navigation so the pages accrue internal links.
+	it("uses findLocalityCategories to render links to category pages", () => {
+		expect(source).toContain("findLocalityCategories");
+		expect(source).toContain("/kategoria/");
+	});
+});


### PR DESCRIPTION
## Problem

Every `/[loc]/kategoria/[category]` page was an orphan — reachable only from the sitemap, with `findLocalityCategories` sitting as fully-tested dead code (zero production callers). Sitemap-only pages accrue no internal PageRank and convert poorly.

## Changes

- **Locality index** (`src/pages/[loc]/index.astro`): renders a "Przeglądaj według kategorii" chip nav linking to each category page. `findLocalityCategories` now has a production caller.
- **All 3 business page layouts** (centered/split/minimal): emit a `/kategoria/` backlink in the hero, `slugify`-ed so the href resolves back through `findCategoryBusinesses` to the category route. Guarded on `category` so category-less pages don't emit a broken link.

Category pages are now linked both **across** from the locality index and **up** from every business page.

## Tests (TDD, red→green)

- `src/pages/[loc]/index.test.ts` — locality index emits `/kategoria/` links via `findLocalityCategories`.
- `src/components/layouts/category-backlink.test.ts` — all 3 layouts emit a slugified category backlink.
- `src/lib/category.test.ts` — no-orphan round-trip guard: every locality category slug resolves to a non-empty category page (guards against slug drift).

## Verification

- Full suite: **470/470** (60 files)
- `pnpm build`, `biome ci`, `astro check` — all clean

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)