### PR TITLE
fix(publish): short cache TTL + 410 gate for non-done pages (#72)

### DIFF
--- a/docs/design/072-publish-lifecycle.md
+++ b/docs/design/072-publish-lifecycle.md
@@ -1,0 +1,96 @@
+# DD-072: Publish lifecycle — cache freshness after approval + unpublish gate
+
+Closes issue #72. Two publish-lifecycle gaps, each needing a small product
+decision before code. Decisions recorded here; test slices implemented in the
+same change.
+
+## Gap 1 — stale cache after owner approval / theme change
+
+### Problem
+
+Public business pages (`src/pages/[loc]/[slug].astro`) and their `.md` exports
+(`src/pages/[loc]/[slug].md.ts`) were served with
+`Cache-Control: public, max-age=86400, s-maxage=604800`. `promoteDraft`
+(`src/lib/site-store.ts`, invoked from owner approval in
+`src/lib/telegram/handlers/client.ts`) and `changeTheme`
+(`src/lib/presentation.ts`) perform no purge.
+
+Consequence: an owner taps "Zatwierdź" in Telegram, opens their page to verify,
+and can see the old content for up to 24h (browser `max-age`). The
+approve-then-verify loop — the emotional peak of the owner flow — was broken by
+design.
+
+### Decision — option (a): short browser `max-age`
+
+`publicCacheControl()` (`src/lib/public-page.ts`) returns
+`public, max-age=300, s-maxage=604800`, used by both the HTML and `.md` routes.
+
+- **Why (a):** cheapest, zero new moving parts, no secrets. There is no edge
+  cache today, so `s-maxage` is inert — the only live pain is the browser
+  `max-age`, which 300s (5 min) reduces to a brief self-heal on the canonical
+  URL. No purge call is added to `promoteDraft`/`changeTheme`.
+- **Why not (b)** (cache-busted `?v=` URL in the approval reply): gives an
+  instant view but leaves the canonical/shareable URL stale; more surface for
+  little gain once (a) heals within minutes.
+- **Why not (c)** (real Cloudflare purge API): most work, and only pays off once
+  custom-domain edge caching exists. Deferred — this is the documented
+  follow-up **for the day `s-maxage` starts to bite**, i.e. when edge caching is
+  enabled.
+
+### Test slice
+
+`src/lib/public-page.test.ts` asserts `publicCacheControl()` has
+`max-age` ≤ 300 and stays `public`. The `.md` route's served response is
+asserted ≤ 300 in `src/pages/[loc]/[slug].md.test.ts`.
+
+## Gap 2 — no unpublish path; pages stay live + indexable regardless of `site_status`
+
+### Problem
+
+- `src/pages/[loc]/[slug].astro` (business query + `isIndexable`) never checked
+  `site_status`.
+- `src/pages/[loc]/[slug].md.ts` served any live R2 object unconditionally.
+- Every listing surface (locality index, category, sitemap, llms.txt) filters
+  `site_status='done'`, and `deleteSite` is only called for drafts.
+
+So a business ever flipped off `done` (owner removal request, GDPR erasure,
+re-classification) silently stayed live + indexable while vanishing from every
+list. No active flip exists in code today, but a removal flow needs the routes
+to stop serving.
+
+### Decision — 410 Gone for non-`done`
+
+`isPubliclyServable(siteStatus)` (`src/lib/site-status.ts`) returns
+`siteStatus === 'done'`, mirroring the `site_status='done'` filter every listing
+surface already uses. Both public routes gate on it:
+
+| Condition                                   | HTML route | `.md` route |
+| ------------------------------------------- | ---------- | ----------- |
+| Live R2 object missing                      | 404        | 404         |
+| Live object present, `site_status != 'done'`| **410**    | **410**     |
+| Live object present, `site_status = 'done'` | 200        | 200         |
+
+- **Why 410 over 404:** the motivating scenarios (removal, GDPR, re-class) are
+  *withdrawals* of previously-servable content; 410 Gone tells crawlers to
+  deindex faster than a 404 they may retry.
+- **Scope:** the gate is a belt-and-suspenders serving check keyed on
+  `site_status` — it withholds even if a future purge/delete is missed. It does
+  **not** itself flip any status or delete R2 objects; a removal flow (R2 delete
+  + status flip) is separate work. The `?draft=1` preview path is intentionally
+  left viewable via its token — the gate only guards the public, non-draft path.
+- **HTML route serves inside Astro SSR**, which the worker test harness mocks
+  (`@astrojs/cloudflare/handler` is stubbed), so the frontmatter can't be
+  invoked directly in-suite. The gate decision is covered behaviorally by
+  `isPubliclyServable` unit tests; the route's wiring is asserted against its
+  `?raw` source; the `.md` sibling route is covered end-to-end.
+
+### Test slice
+
+- `src/lib/site-status.test.ts`: `isPubliclyServable` — `'done'` → true;
+  `pending`/`in_progress`/`ineligible`/`null`/`undefined` → false.
+- `src/pages/[loc]/[slug].md.test.ts`: seed a live object for an `ineligible`
+  business → 410; a `done` business → 200 (short cache); missing object → 404.
+  (410 and short-cache both failed before this change; both served 200 / 24h.)
+- `src/pages/[loc]/[slug].astro.test.ts`: `?raw` wiring — biz `SELECT` includes
+  `site_status`, gate calls `isPubliclyServable(biz.site_status)` and returns
+  `status: 410`, and the header uses `publicCacheControl()`.

--- a/src/lib/public-page.test.ts
+++ b/src/lib/public-page.test.ts
@@ -5,6 +5,7 @@ import {
 	ASSISTANT_FIRST_MESSAGE,
 	ASSISTANT_PRIVACY_NOTICE,
 	buildPublicBusinessPageModel,
+	publicCacheControl,
 } from "./public-page";
 import type { BizData } from "./structured-data";
 
@@ -127,5 +128,25 @@ describe("buildPublicBusinessPageModel", () => {
 
 		expect(renderedCopy.toLowerCase()).not.toContain("seller");
 		expect(renderedCopy.toLowerCase()).not.toContain("sprzedaw");
+	});
+});
+
+describe("publicCacheControl", () => {
+	// Issue #72 gap 1: promoteDraft/changeTheme perform no cache purge, so the old
+	// 24h browser max-age broke the owner's approve-then-verify loop. Decision (a):
+	// lower browser max-age to <= 5 min so the canonical URL self-heals quickly.
+	const parseMaxAge = (header: string): number | null => {
+		const match = header.match(/(?:^|[,\s])max-age=(\d+)/i);
+		return match ? Number(match[1]) : null;
+	};
+
+	it("keeps the browser max-age at or below 300 seconds", () => {
+		const maxAge = parseMaxAge(publicCacheControl());
+		expect(maxAge).not.toBeNull();
+		expect(maxAge as number).toBeLessThanOrEqual(300);
+	});
+
+	it("stays publicly cacheable", () => {
+		expect(publicCacheControl()).toMatch(/(?:^|[,\s])public(?:[,\s]|$)/);
 	});
 });

--- a/src/lib/public-page.ts
+++ b/src/lib/public-page.ts
@@ -2,6 +2,20 @@ import type { SiteData, SiteService } from "../types/site";
 import { formatOperatingHours } from "./operating-hours";
 import type { BizData } from "./structured-data";
 
+/**
+ * Cache-Control for public (non-draft) business pages and their .md exports.
+ *
+ * Issue #72 gap 1: promoteDraft (owner approval) and changeTheme perform no
+ * cache purge, so the previous 24h browser `max-age` left owners staring at
+ * stale content right after tapping "Zatwierdź" — the emotional peak of the
+ * flow. Decision (a): keep the browser `max-age` short (5 min) so the canonical
+ * URL self-heals without any purge machinery. `s-maxage` is inert until edge
+ * caching is enabled; a real CF purge (option c) is the follow-up for that day.
+ */
+export function publicCacheControl(): string {
+	return "public, max-age=300, s-maxage=604800";
+}
+
 export const ASSISTANT_CTA_LABEL = "Zapytaj asystenta";
 export const ASSISTANT_FIRST_MESSAGE =
 	"Cześć! Jestem asystentem AI i nie reprezentuję bezpośrednio tego miejsca. Zapytaj mnie o to miejsce - jeśli sprawa wymaga kontaktu z człowiekiem, podpowiem Ci najlepszy następny krok.";

--- a/src/lib/site-status.test.ts
+++ b/src/lib/site-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifyBusinessSiteStatus } from "./site-status";
+import { classifyBusinessSiteStatus, isPubliclyServable } from "./site-status";
 
 describe("classifyBusinessSiteStatus", () => {
 	it("returns pending when phone is present and website is missing", () => {
@@ -41,5 +41,26 @@ describe("classifyBusinessSiteStatus", () => {
 		expect(
 			classifyBusinessSiteStatus({ website: "", phone: "+48123456789" }),
 		).toEqual({ status: "pending", reason: null });
+	});
+});
+
+describe("isPubliclyServable", () => {
+	// Issue #72 gap 2: business pages and .md exports served any live R2 object
+	// regardless of site_status, while every listing surface filters
+	// site_status='done'. Only 'done' businesses may be served/indexed publicly;
+	// any other status (or a missing row) means the page was withdrawn → 410 Gone.
+	it("serves only businesses whose site_status is 'done'", () => {
+		expect(isPubliclyServable("done")).toBe(true);
+	});
+
+	it("withholds every non-done status", () => {
+		expect(isPubliclyServable("pending")).toBe(false);
+		expect(isPubliclyServable("in_progress")).toBe(false);
+		expect(isPubliclyServable("ineligible")).toBe(false);
+	});
+
+	it("withholds when the status is missing", () => {
+		expect(isPubliclyServable(null)).toBe(false);
+		expect(isPubliclyServable(undefined)).toBe(false);
 	});
 });

--- a/src/lib/site-status.ts
+++ b/src/lib/site-status.ts
@@ -11,6 +11,20 @@ export interface SiteStatusClassification {
  * presence of website and phone. Priority: website > phone — if a business
  * already has a website it is ineligible regardless of phone status.
  */
+/**
+ * Whether a business may be served on its public page and .md export, and
+ * indexed. Issue #72 gap 2: routes previously served any live R2 object
+ * regardless of status, so a business flipped off 'done' (owner removal, GDPR
+ * erasure, re-classification) stayed live + indexable while vanishing from
+ * every list. Only 'done' is public — everything else means withdrawn (410).
+ * Mirrors the `site_status='done'` filter used by all listing surfaces.
+ */
+export function isPubliclyServable(
+	siteStatus: SiteStatus | string | null | undefined,
+): boolean {
+	return siteStatus === "done";
+}
+
 export function classifyBusinessSiteStatus(biz: {
 	website: string | null;
 	phone: string | null;

--- a/src/pages/[loc]/[slug].astro
+++ b/src/pages/[loc]/[slug].astro
@@ -2,6 +2,8 @@
 import BusinessSite from '../../components/BusinessSite.astro';
 import { env } from 'cloudflare:workers';
 import { getPublishedOrPreviewSite } from '../../lib/site-store';
+import { isPubliclyServable } from '../../lib/site-status';
+import { publicCacheControl } from '../../lib/public-page';
 import { formatLocalityLabel } from '../../lib/locality-label';
 
 const { loc, slug } = Astro.params;
@@ -20,14 +22,23 @@ const site = await getPublishedOrPreviewSite(r2, db, loc, slug, {
 if (!site) return new Response('Not Found', { status: 404 });
 
 const biz = await db.prepare(`
-  SELECT b.title, b.phone, b.address, b.category, b.gps_lat, b.gps_lng, b.rating, b.reviews_count, b.operating_hours
+  SELECT b.title, b.phone, b.address, b.category, b.gps_lat, b.gps_lng, b.rating, b.reviews_count, b.operating_hours, b.site_status
   FROM businesses b
   JOIN localities l ON b.locality_id = l.id
   WHERE l.slug = ? AND b.slug = ?
 `).bind(loc, slug).first<{
   title: string; phone: string; address: string; category: string;
   gps_lat: number; gps_lng: number; rating: number | null; reviews_count: number | null; operating_hours: string | null;
+  site_status: string;
 }>();
+
+// Issue #72 gap 2: a live R2 object may outlive its 'done' status (owner
+// removal, GDPR erasure, re-classification). On the public (non-draft) path,
+// withhold anything not 'done' as 410 Gone so it stops being served + indexed.
+// The draft-preview path stays intentionally viewable via its token.
+if (!isDraft && biz && !isPubliclyServable(biz.site_status)) {
+  return new Response('Gone', { status: 410 });
+}
 
 const locRow = await db.prepare(`SELECT name, gmi_name, pow_name FROM localities WHERE slug = ?`)
   .bind(loc).first<{ name: string; gmi_name: string | null; pow_name: string | null }>();
@@ -52,7 +63,7 @@ const { results: relatedBusinesses } = await db.prepare(`
 if (isDraft) {
   Astro.response.headers.set('Cache-Control', 'no-store');
 } else {
-  Astro.response.headers.set('Cache-Control', 'public, max-age=86400, s-maxage=604800');
+  Astro.response.headers.set('Cache-Control', publicCacheControl());
 }
 ---
 

--- a/src/pages/[loc]/[slug].astro.test.ts
+++ b/src/pages/[loc]/[slug].astro.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import source from "./[slug].astro?raw";
+
+// Issue #72: the public HTML route runs inside Astro's SSR pipeline, which the
+// worker test harness mocks out (@astrojs/cloudflare/handler is stubbed), so the
+// frontmatter can't be invoked directly. The gate decision itself lives in the
+// behaviorally-tested isPubliclyServable() (see site-status.test.ts) and the
+// cache value in publicCacheControl() (see public-page.test.ts); these
+// assertions verify the route wires both in. The .md sibling route is covered
+// end-to-end in [slug].md.test.ts.
+describe("[slug].astro publish gate wiring", () => {
+	it("adds site_status to the business SELECT so the gate has data", () => {
+		expect(source).toContain("b.operating_hours, b.site_status");
+	});
+
+	it("withholds non-done businesses with a 410 via isPubliclyServable", () => {
+		expect(source).toContain("isPubliclyServable(biz.site_status)");
+		expect(source).toMatch(/status:\s*410/);
+	});
+
+	it("serves the public page with the short-lived cache header", () => {
+		expect(source).toContain("publicCacheControl");
+		expect(source).not.toContain("max-age=86400");
+	});
+});

--- a/src/pages/[loc]/[slug].md.test.ts
+++ b/src/pages/[loc]/[slug].md.test.ts
@@ -1,0 +1,74 @@
+import { env } from "cloudflare:workers";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetDb } from "../../../test/seed";
+import { putSite } from "../../lib/site-store";
+import type { SiteData } from "../../types/site";
+import { GET } from "./[slug].md";
+
+const STUB_SITE: SiteData = {
+	hero: { headline: "Hydraulik Warszawa", subheadline: "Szybka pomoc" },
+	about: { title: "O firmie", text: "Opis firmy." },
+	services: [{ name: "Naprawa", description: "Usuwanie awarii" }],
+	contact: {
+		cta_text: "Zadzwoń",
+		phone: "+48123456789",
+		address: "ul. Marszałkowska 1, Warszawa",
+	},
+	seo: { title: "Hydraulik Warszawa", description: "Lokalna firma" },
+};
+
+const invoke = (loc: string, slug: string) =>
+	GET({ params: { loc, slug } } as unknown as Parameters<typeof GET>[0]);
+
+const parseMaxAge = (header: string | null): number | null => {
+	const match = header?.match(/(?:^|[,\s])max-age=(\d+)/i);
+	return match ? Number(match[1]) : null;
+};
+
+// Issue #72 gap 2: the .md export served any live R2 object unconditionally,
+// with no site_status check — so a business withdrawn from 'done' (owner
+// removal, GDPR erasure, re-classification) stayed live + machine-readable
+// while disappearing from every list. The export must gate on site_status.
+describe("GET [slug].md", () => {
+	beforeEach(async () => {
+		await resetDb(env.leadgen);
+		const list = await env.sites.list();
+		for (const obj of list.objects) {
+			await env.sites.delete(obj.key);
+		}
+	});
+
+	it("serves markdown for a live, done business with a short max-age", async () => {
+		await putSite(
+			env.sites,
+			"live",
+			"warszawa",
+			"hydraulik-warszawa",
+			STUB_SITE,
+		);
+
+		const res = await invoke("warszawa", "hydraulik-warszawa");
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toContain("text/markdown");
+		expect(
+			parseMaxAge(res.headers.get("Cache-Control")) ?? 0,
+		).toBeLessThanOrEqual(300);
+		expect(await res.text()).toContain("Hydraulik Warszawa");
+	});
+
+	it("returns 410 Gone when the live object exists but site_status is not done", async () => {
+		// Business 5 (sklep-agd, warszawa) is seeded with site_status='ineligible'.
+		await putSite(env.sites, "live", "warszawa", "sklep-agd", STUB_SITE);
+
+		const res = await invoke("warszawa", "sklep-agd");
+
+		expect(res.status).toBe(410);
+	});
+
+	it("returns 404 when no live object exists", async () => {
+		const res = await invoke("warszawa", "hydraulik-warszawa");
+
+		expect(res.status).toBe(404);
+	});
+});

--- a/src/pages/[loc]/[slug].md.ts
+++ b/src/pages/[loc]/[slug].md.ts
@@ -1,6 +1,7 @@
 import { env } from "cloudflare:workers";
 import type { APIRoute } from "astro";
-import { ASSISTANT_CTA_LABEL } from "../../lib/public-page";
+import { ASSISTANT_CTA_LABEL, publicCacheControl } from "../../lib/public-page";
+import { isPubliclyServable } from "../../lib/site-status";
 import type { SiteData } from "../../types/site";
 
 function siteToMarkdown(site: SiteData, title: string, url: string): string {
@@ -49,10 +50,16 @@ export const GET: APIRoute = async ({ params }) => {
 	const db = env.leadgen as D1Database;
 	const biz = await db
 		.prepare(
-			`SELECT b.title FROM businesses b JOIN localities l ON b.locality_id = l.id WHERE l.slug = ? AND b.slug = ?`,
+			`SELECT b.title, b.site_status FROM businesses b JOIN localities l ON b.locality_id = l.id WHERE l.slug = ? AND b.slug = ?`,
 		)
 		.bind(loc, slug)
-		.first<{ title: string }>();
+		.first<{ title: string; site_status: string }>();
+
+	// Issue #72 gap 2: a live R2 object may outlive its 'done' status (owner
+	// removal, GDPR erasure, re-classification). Withhold anything not 'done'.
+	if (biz && !isPubliclyServable(biz.site_status)) {
+		return new Response("Gone", { status: 410 });
+	}
 
 	const title = biz?.title ?? site.hero.headline;
 	const canonical = `https://wizytowka.link/${loc}/${slug}`;
@@ -61,7 +68,7 @@ export const GET: APIRoute = async ({ params }) => {
 	return new Response(md, {
 		headers: {
 			"Content-Type": "text/markdown; charset=utf-8",
-			"Cache-Control": "public, max-age=86400, s-maxage=604800",
+			"Cache-Control": publicCacheControl(),
 			Link: `<${canonical}>; rel="canonical"`,
 		},
 	});


### PR DESCRIPTION
Closes #72.

Two publish-lifecycle gaps, each with a small product decision recorded in `docs/design/072-publish-lifecycle.md`.

## Gap 1 — stale cache after owner approval / theme change
`promoteDraft` (owner approval) and `changeTheme` did no cache purge, so with the old `max-age=86400` an owner saw stale content for up to 24h right after tapping "Zatwierdź" — the emotional peak of the flow.

**Decision (a):** `publicCacheControl()` returns `public, max-age=300, s-maxage=604800`, used by both the HTML route and the `.md` export. Short browser TTL self-heals the canonical URL in ≤5 min; no purge machinery. `s-maxage` is inert until edge caching exists — a real CF purge (option c) is the documented follow-up for that day.

## Gap 2 — no unpublish gate
Both public routes served any live R2 object regardless of `site_status`, while every listing surface filters `site_status='done'`. A business flipped off `done` (owner removal, GDPR erasure, re-classification) stayed live + indexable while vanishing from every list.

**Decision — 410 Gone:** both routes gate on `isPubliclyServable(siteStatus)` (`=== 'done'`).

| Condition | HTML | `.md` |
|---|---|---|
| Live object missing | 404 | 404 |
| Live object present, `site_status != 'done'` | **410** | **410** |
| Live object present, `site_status = 'done'` | 200 | 200 |

410 over 404 so crawlers deindex withdrawn pages faster. The `?draft=1` preview path stays viewable via its token. The gate is a serving guard only — it does not itself flip status or delete R2 (a removal flow is separate work).

## Tests (TDD red→green)
- `public-page.test.ts` — `publicCacheControl()` `max-age` ≤ 300, stays `public`.
- `site-status.test.ts` — `isPubliclyServable`: `done`→true; `pending`/`in_progress`/`ineligible`/`null`/`undefined`→false.
- `[slug].md.test.ts` (new) — end-to-end: ineligible+live object → 410; done → 200 (short cache); missing → 404.
- `[slug].astro.test.ts` (new) — `?raw` wiring: biz SELECT includes `site_status`, gate calls `isPubliclyServable(biz.site_status)` → 410, header uses `publicCacheControl()`. (Astro SSR is mocked in-harness so the frontmatter can't be invoked directly — the gate decision is covered behaviorally by `isPubliclyServable`; the `.md` sibling proves the 410 end-to-end.)

`pnpm test` (481 passed), `pnpm lint:ci`, and `pnpm types` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)