### PR TITLE
feat(chat): notify on meaningful chat reopen after quiet period

### DIFF
--- a/migrations/0018-chat-reopen-tracking.sql
+++ b/migrations/0018-chat-reopen-tracking.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chat_sessions ADD COLUMN last_opened_at TEXT;
+ALTER TABLE chat_sessions ADD COLUMN last_reopen_notified_at TEXT;

--- a/src/lib/chat-reopen.test.ts
+++ b/src/lib/chat-reopen.test.ts
@@ -1,0 +1,218 @@
+import { env } from "cloudflare:workers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetDb } from "../../test/seed";
+import { sendChatReopenNotification, startChatSession } from "./chat";
+
+const PAGE = { locSlug: "warszawa", businessSlug: "hydraulik-warszawa" };
+
+async function openChat(startedAt: string, sessionId?: string) {
+	const result = await startChatSession(
+		env.leadgen,
+		{ ...PAGE, sessionId: sessionId ?? null },
+		{
+			referrer: "https://example.test/source",
+			userAgent: "Vitest Agent",
+			startedAt,
+		},
+	);
+	if (!result) throw new Error("failed to open chat session");
+	return result;
+}
+
+async function readSession(sessionId: string) {
+	return env.leadgen
+		.prepare(
+			"SELECT last_opened_at, last_reopen_notified_at FROM chat_sessions WHERE id = ?",
+		)
+		.bind(sessionId)
+		.first<{
+			last_opened_at: string | null;
+			last_reopen_notified_at: string | null;
+		}>();
+}
+
+describe("startChatSession reopen detection", () => {
+	beforeEach(async () => {
+		await resetDb(env.leadgen);
+	});
+
+	// Assumptions for issue #49:
+	// A brand-new session is not a reopen; its last_opened_at equals the start time.
+	// Reopening the same still-active session is flagged reopened and advances last_opened_at.
+	it("marks a brand-new session as not reopened and records the open time", async () => {
+		const result = await openChat("2026-05-26T10:00:00.000Z");
+
+		expect(result).toEqual({
+			sessionId: expect.any(String),
+			status: "active",
+			reopened: false,
+		});
+		const row = await readSession(result.sessionId);
+		expect(row?.last_opened_at).toBe("2026-05-26T10:00:00.000Z");
+	});
+
+	it("marks reopening the same active session as reopened and advances the open time", async () => {
+		const first = await openChat("2026-05-26T10:00:00.000Z");
+		const reopened = await openChat(
+			"2026-05-26T10:20:00.000Z",
+			first.sessionId,
+		);
+
+		expect(reopened).toEqual({
+			sessionId: first.sessionId,
+			status: "active",
+			reopened: true,
+		});
+		const row = await readSession(first.sessionId);
+		expect(row?.last_opened_at).toBe("2026-05-26T10:20:00.000Z");
+	});
+});
+
+function mockTelegramFetch() {
+	return vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+		const url = input.toString();
+		if (url.includes("api.telegram.org")) {
+			return Response.json({
+				ok: true,
+				result: { message_id: 1, chat: { id: 1, type: "private" }, date: 0 },
+			});
+		}
+		throw new Error(`Unexpected fetch: ${url}`);
+	});
+}
+
+function mockRejectedTelegramFetch() {
+	return vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+		const url = input.toString();
+		if (url.includes("api.telegram.org")) {
+			return Response.json({
+				ok: false,
+				error_code: 400,
+				description: "Bad Request: chat not found",
+			});
+		}
+		throw new Error(`Unexpected fetch: ${url}`);
+	});
+}
+
+function telegramCalls(fetchMock: ReturnType<typeof mockTelegramFetch>) {
+	return fetchMock.mock.calls.filter(([input]) =>
+		input.toString().includes("api.telegram.org"),
+	);
+}
+
+async function markStartNotified(sessionId: string, sentAt: string) {
+	await env.leadgen
+		.prepare("UPDATE chat_sessions SET telegram_start_sent_at = ? WHERE id = ?")
+		.bind(sentAt, sessionId)
+		.run();
+}
+
+describe("sendChatReopenNotification", () => {
+	let originalFetch: typeof fetch;
+	let fetchMock: ReturnType<typeof mockTelegramFetch>;
+
+	beforeEach(async () => {
+		await resetDb(env.leadgen);
+		originalFetch = globalThis.fetch;
+		fetchMock = mockTelegramFetch();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	// Assumptions for issue #49:
+	// A reopen past the quiet period sends exactly one "reopened" Telegram notification,
+	// carrying the page slug, reopen timestamp, and referrer, and stamps last_reopen_notified_at.
+	it("sends one reopen notification when the session is reopened after the quiet period", async () => {
+		const session = await openChat("2026-05-26T10:00:00.000Z");
+		await markStartNotified(session.sessionId, "2026-05-26T10:00:00.000Z");
+		await openChat("2026-05-26T10:16:00.000Z", session.sessionId);
+
+		await sendChatReopenNotification(
+			env,
+			session.sessionId,
+			new Date("2026-05-26T10:16:00.000Z"),
+		);
+
+		const calls = telegramCalls(fetchMock);
+		expect(calls).toHaveLength(1);
+		const payload = JSON.parse(calls[0][1]?.body as string) as {
+			chat_id: string;
+			text: string;
+		};
+		expect(payload.chat_id).toBe("100001");
+		expect(payload.text).toContain("ponownie");
+		expect(payload.text).toContain("warszawa/hydraulik-warszawa");
+		expect(payload.text).toContain("2026-05-26T10:16:00.000Z");
+		expect(payload.text).toContain("https://example.test/source");
+		expect(payload.text).toContain(
+			`Transkrypt: https://example.test/panel/test-token?chat=${session.sessionId}`,
+		);
+
+		const row = await readSession(session.sessionId);
+		expect(row?.last_reopen_notified_at).toBe("2026-05-26T10:16:00.000Z");
+	});
+
+	// Reopening repeatedly within the quiet period must not spam Telegram.
+	it("does not send a reopen notification within the quiet period", async () => {
+		const session = await openChat("2026-05-26T10:00:00.000Z");
+		await markStartNotified(session.sessionId, "2026-05-26T10:00:00.000Z");
+		await openChat("2026-05-26T10:05:00.000Z", session.sessionId);
+
+		await sendChatReopenNotification(
+			env,
+			session.sessionId,
+			new Date("2026-05-26T10:05:00.000Z"),
+		);
+
+		expect(telegramCalls(fetchMock)).toHaveLength(0);
+		const row = await readSession(session.sessionId);
+		expect(row?.last_reopen_notified_at).toBeNull();
+	});
+
+	// After one reopen notification, a further reopen within the quiet period of
+	// that notification must stay silent — the baseline advances to the last reopen.
+	it("does not re-notify for a reopen within the quiet period of a prior reopen", async () => {
+		const session = await openChat("2026-05-26T10:00:00.000Z");
+		await markStartNotified(session.sessionId, "2026-05-26T10:00:00.000Z");
+
+		await openChat("2026-05-26T10:16:00.000Z", session.sessionId);
+		await sendChatReopenNotification(
+			env,
+			session.sessionId,
+			new Date("2026-05-26T10:16:00.000Z"),
+		);
+
+		await openChat("2026-05-26T10:20:00.000Z", session.sessionId);
+		await sendChatReopenNotification(
+			env,
+			session.sessionId,
+			new Date("2026-05-26T10:20:00.000Z"),
+		);
+
+		expect(telegramCalls(fetchMock)).toHaveLength(1);
+		const row = await readSession(session.sessionId);
+		expect(row?.last_reopen_notified_at).toBe("2026-05-26T10:16:00.000Z");
+	});
+
+	// A failed delivery must not consume the quiet-period budget, so the next
+	// reopen can retry instead of being silently suppressed.
+	it("does not mark a reopen as notified when Telegram rejects delivery", async () => {
+		globalThis.fetch = mockRejectedTelegramFetch() as unknown as typeof fetch;
+		const session = await openChat("2026-05-26T10:00:00.000Z");
+		await markStartNotified(session.sessionId, "2026-05-26T10:00:00.000Z");
+		await openChat("2026-05-26T10:16:00.000Z", session.sessionId);
+
+		await sendChatReopenNotification(
+			env,
+			session.sessionId,
+			new Date("2026-05-26T10:16:00.000Z"),
+		);
+
+		const row = await readSession(session.sessionId);
+		expect(row?.last_reopen_notified_at).toBeNull();
+	});
+});

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -18,6 +18,7 @@ export interface StartChatMeta {
 export interface StartChatResult {
 	sessionId: string;
 	status: "active";
+	reopened: boolean;
 }
 
 export interface ChatMessageInput {
@@ -107,6 +108,18 @@ interface ChatNotificationSessionRow {
 	started_at: string;
 	referrer: string | null;
 	telegram_start_sent_at: string | null;
+}
+
+interface ChatReopenNotificationSessionRow {
+	id: string;
+	locality_slug: string;
+	business_slug: string;
+	status: "active" | "ended";
+	referrer: string | null;
+	started_at: string;
+	last_opened_at: string | null;
+	telegram_start_sent_at: string | null;
+	last_reopen_notified_at: string | null;
 }
 
 interface ChatEndNotificationSessionRow {
@@ -248,7 +261,7 @@ async function findBusinessPage(
 async function findActiveSession(
 	db: D1Database,
 	input: StartChatInput,
-): Promise<StartChatResult | null> {
+): Promise<{ sessionId: string; status: "active" } | null> {
 	if (!input.sessionId) return null;
 	const row = await db
 		.prepare(
@@ -297,6 +310,10 @@ export async function startChatSession(
 	const startedAt = meta.startedAt ?? new Date().toISOString();
 	const existing = await findActiveSession(db, input);
 	if (existing) {
+		await db
+			.prepare("UPDATE chat_sessions SET last_opened_at = ? WHERE id = ?")
+			.bind(startedAt, existing.sessionId)
+			.run();
 		await recordChatStartEvent(db, {
 			input,
 			sessionId: existing.sessionId,
@@ -304,7 +321,7 @@ export async function startChatSession(
 			referrer: meta.referrer,
 			userAgent: meta.userAgent,
 		});
-		return existing;
+		return { ...existing, reopened: true };
 	}
 
 	const business = await findBusinessPage(db, input);
@@ -316,8 +333,8 @@ export async function startChatSession(
 		.prepare(
 			`INSERT INTO chat_sessions (
          id, business_id, locality_slug, business_slug, started_at,
-         status, referrer, user_agent
-       ) VALUES (?, ?, ?, ?, ?, 'active', ?, ?)`,
+         status, referrer, user_agent, last_opened_at
+       ) VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?)`,
 		)
 		.bind(
 			sessionId,
@@ -327,6 +344,7 @@ export async function startChatSession(
 			startedAt,
 			meta.referrer,
 			meta.userAgent,
+			startedAt,
 		)
 		.run();
 
@@ -338,7 +356,7 @@ export async function startChatSession(
 		userAgent: meta.userAgent,
 	});
 
-	return { sessionId, status: "active" };
+	return { sessionId, status: "active", reopened: false };
 }
 
 const CHAT_MODEL = "glm-5";
@@ -346,6 +364,7 @@ const CHAT_TEMPERATURE = 0.2;
 const CHAT_MAX_TOKENS = 300;
 const PROVIDER_ERROR_BODY_CAP_BYTES = 2048;
 export const CHAT_INACTIVITY_TIMEOUT_MINUTES = 30;
+export const CHAT_REOPEN_QUIET_PERIOD_MINUTES = 15;
 const ZAI_CHAT_COMPLETIONS_URL =
 	"https://api.z.ai/api/coding/paas/v4/chat/completions";
 const CHAT_SYSTEM_PROMPT = `Jestes polskim asystentem informacyjnym strony wizytowkowej.
@@ -992,6 +1011,24 @@ function formatChatStartedMessage(
 	].join("\n");
 }
 
+function formatChatReopenedMessage(
+	session: ChatReopenNotificationSessionRow,
+	sellerToken: string,
+	adminPanelUrl?: string,
+): string {
+	const pageSlug = `${session.locality_slug}/${session.business_slug}`;
+	const transcript = transcriptUrl(session.id, sellerToken, adminPanelUrl);
+	const reopenedAt = session.last_opened_at ?? session.started_at;
+	return [
+		"🔁 <b>Chat ponownie otwarty</b>",
+		"",
+		`Strona: ${escapeHtml(pageSlug)}`,
+		`Ponownie otwarto: ${escapeHtml(reopenedAt)}`,
+		`Referrer: ${escapeHtml(session.referrer ?? "brak")}`,
+		`Transkrypt: ${escapeHtml(transcript)}`,
+	].join("\n");
+}
+
 function formatChatEndedMessage(
 	session: ChatEndNotificationSessionRow,
 	sellerToken: string,
@@ -1043,6 +1080,83 @@ export async function sendChatStartNotification(
 			"UPDATE chat_sessions SET telegram_start_sent_at = ? WHERE id = ? AND telegram_start_sent_at IS NULL",
 		)
 		.bind(new Date().toISOString(), session.id)
+		.run();
+}
+
+export async function sendChatReopenNotification(
+	env: ChatNotificationEnv,
+	sessionId: string,
+	now = new Date(),
+): Promise<void> {
+	const session = await env.leadgen
+		.prepare(
+			`SELECT id, locality_slug, business_slug, status, referrer, started_at,
+              last_opened_at, telegram_start_sent_at, last_reopen_notified_at
+       FROM chat_sessions WHERE id = ?`,
+		)
+		.bind(sessionId)
+		.first<ChatReopenNotificationSessionRow>();
+	if (!session || session.status !== "active") return;
+
+	const cutoff = new Date(
+		now.getTime() - CHAT_REOPEN_QUIET_PERIOD_MINUTES * 60 * 1000,
+	).toISOString();
+	const lastNotifiedAt =
+		session.last_reopen_notified_at ??
+		session.telegram_start_sent_at ??
+		session.started_at;
+	if (lastNotifiedAt > cutoff) return;
+
+	const recipient = await env.leadgen
+		.prepare(
+			"SELECT notify_chat_id, token FROM sellers WHERE notify_chat_id IS NOT NULL ORDER BY id LIMIT 1",
+		)
+		.first<{ notify_chat_id: string; token: string }>();
+	if (!recipient) return;
+
+	const notifiedAt = now.toISOString();
+	const previous = session.last_reopen_notified_at;
+	const claim = await env.leadgen
+		.prepare(
+			`UPDATE chat_sessions SET last_reopen_notified_at = ?
+       WHERE id = ? AND status = 'active'
+         AND COALESCE(last_reopen_notified_at, telegram_start_sent_at, started_at) <= ?`,
+		)
+		.bind(notifiedAt, session.id, cutoff)
+		.run();
+	if (claim.meta.changes !== 1) return;
+
+	try {
+		const delivery = await sendMessage(
+			env.TG_NOTIFY_BOT_TOKEN,
+			recipient.notify_chat_id,
+			formatChatReopenedMessage(session, recipient.token, env.ADMIN_PANEL_URL),
+		);
+		if (delivery.ok) return;
+	} catch (error) {
+		await restoreReopenNotifiedAt(
+			env.leadgen,
+			session.id,
+			notifiedAt,
+			previous,
+		);
+		throw error;
+	}
+
+	await restoreReopenNotifiedAt(env.leadgen, session.id, notifiedAt, previous);
+}
+
+async function restoreReopenNotifiedAt(
+	db: D1Database,
+	sessionId: string,
+	claimedAt: string,
+	previous: string | null,
+): Promise<void> {
+	await db
+		.prepare(
+			"UPDATE chat_sessions SET last_reopen_notified_at = ? WHERE id = ? AND last_reopen_notified_at = ?",
+		)
+		.bind(previous, sessionId, claimedAt)
 		.run();
 }
 

--- a/src/pages/api/chat/start.test.ts
+++ b/src/pages/api/chat/start.test.ts
@@ -272,6 +272,47 @@ describe("POST /api/chat/start", () => {
 		expect(telegramCalls(fetchMock)).toHaveLength(1);
 	});
 
+	it("sends a reopen notification when an active session is reopened after the quiet period", async () => {
+		const sessionId = "reopen-past-quiet-session";
+		await env.leadgen
+			.prepare(
+				`INSERT INTO chat_sessions (
+           id, business_id, locality_slug, business_slug, started_at, status,
+           referrer, user_agent, last_opened_at, telegram_start_sent_at
+         ) VALUES (?, ?, 'warszawa', 'hydraulik-warszawa', ?, 'active',
+                   'https://example.test/source', 'Vitest Agent', ?, ?)`,
+			)
+			.bind(
+				sessionId,
+				TEST_IDS.businesses.hydraulikWarszawa,
+				"2020-01-01T00:00:00.000Z",
+				"2020-01-01T00:00:00.000Z",
+				"2020-01-01T00:00:00.000Z",
+			)
+			.run();
+
+		const { response, settled } = await submitChatStart({
+			locSlug: "warszawa",
+			businessSlug: "hydraulik-warszawa",
+			sessionId,
+		});
+		const body = (await response.json()) as ChatStartResponse;
+		await settled;
+
+		expect(body.sessionId).toBe(sessionId);
+		const calls = telegramCalls(fetchMock);
+		expect(calls).toHaveLength(1);
+		const payload = JSON.parse(calls[0][1]?.body as string) as { text: string };
+		expect(payload.text).toContain("ponownie");
+		expect(payload.text).toContain("warszawa/hydraulik-warszawa");
+
+		const row = await env.leadgen
+			.prepare("SELECT last_reopen_notified_at FROM chat_sessions WHERE id = ?")
+			.bind(sessionId)
+			.first<{ last_reopen_notified_at: string | null }>();
+		expect(row?.last_reopen_notified_at).toEqual(expect.any(String));
+	});
+
 	it("does not mark a start notification as sent when Telegram rejects delivery", async () => {
 		globalThis.fetch = mockRejectedTelegramFetch() as unknown as typeof fetch;
 		const { response, settled } = await submitChatStart({

--- a/src/pages/api/chat/start.ts
+++ b/src/pages/api/chat/start.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import type { APIRoute } from "astro";
 import {
 	parseStartChatInput,
+	sendChatReopenNotification,
 	sendChatStartNotification,
 	startChatSession,
 } from "../../../lib/chat";
@@ -37,7 +38,10 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!result) return json({ error: "nie znaleziono strony" }, 404);
 
 	locals.cfContext.waitUntil(
-		sendChatStartNotification(env, result.sessionId).catch((error) => {
+		(result.reopened
+			? sendChatReopenNotification(env, result.sessionId)
+			: sendChatStartNotification(env, result.sessionId)
+		).catch((error) => {
 			console.error("chat start notification failed:", error);
 		}),
 	);


### PR DESCRIPTION
## What

Reopening an active chat session for the same business now sends a Telegram **reopen** notification once the configurable quiet period (15 min) has elapsed. Repeated reopens within the window stay idempotent, and brand-new visitor sessions keep the existing start notification.

## Why

Chat start notifications are idempotent per active session, so a meaningful later reopen by the same visitor was invisible to Telegram. This adds a "reopen" policy while preserving reclick/refresh idempotency.

## How

- Migration `0018-chat-reopen-tracking.sql`: adds `last_opened_at` + `last_reopen_notified_at` to `chat_sessions`.
- `startChatSession` returns a `reopened` flag and stamps `last_opened_at`.
- `sendChatReopenNotification`: quiet-period gate via an atomic claim over `COALESCE(last_reopen_notified_at, telegram_start_sent_at, started_at)`, with reset-on-failure so a failed delivery doesn't consume the quiet-period budget.
- `/api/chat/start` dispatches reopen vs start notification.
- Quiet period is **15 min** (an exported constant), deliberately under the 30-min inactivity sweep so it fires on genuine returns.

## Acceptance criteria (all met)

- ✅ Reopen after the quiet period → one reopen notification
- ✅ Repeated reopen within the quiet period → no duplicates
- ✅ Brand-new session → existing start notification
- ✅ Existing start-notification idempotency tests pass
- ✅ `pnpm test` (488 passing) and `pnpm build` pass; Biome + astro check clean

## Deploy note

⚠️ Migration `0018` must be applied to prod via `pnpm db:migrate:remote` before/with this merge, or the chat crons will error on the missing columns.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)