### PR TITLE
chore(deploy): upload production secrets via wrangler --secrets-file

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,6 +9,7 @@ Lead-gen platform: scrapes Polish businesses via SerpAPI, generates static "wizy
 - **Styling**: TailwindCSS 4 via `@tailwindcss/vite`, `@theme inline` tokens in `src/styles/base.css` (no tailwind.config)
 - **Lint/format**: Biome (not ESLint/Prettier) — `biome.json`
 - **Tests**: Vitest + `@cloudflare/vitest-pool-workers` (real D1/R2 via Miniflare), co-located `foo.test.ts` next to `foo.ts`
+- **Node**: requires **≥22.15** (pinned to 24 via `.nvmrc` — run `nvm use`). Older Node breaks `astro build`/`astro check` with `node:module ... registerHooks` because the `@astrojs/cloudflare` build path uses Vite's module-runner.
 
 ## Project structure
 
@@ -78,7 +79,8 @@ docs/design/                     # Numbered design docs (read before implementin
 <important if="you need to run non-trivial commands (standard dev/build/test are in package.json)">
 ```bash
 pnpm seed                          # WIPES local D1+R2, re-migrates, re-seeds
-pnpm db:migrate:remote             # Apply D1 migrations to production
+pnpm db:migrate:remote             # Apply D1 migrations to production (run BEFORE deploying code that uses new columns)
+pnpm run build && pnpm run deploy  # Build, then deploy — deploy = `wrangler deploy --secrets-file .production.vars`
 curl http://localhost:8787/cdn-cgi/handler/scheduled  # Trigger crons locally (requires pnpm preview, NOT pnpm dev)
 ```
 
@@ -141,7 +143,7 @@ Files: `src/lib/themes.ts` (palettes), `src/lib/category.ts` (category → palet
 - **Admin auth**: single `ADMIN_TOKEN` secret, `x-admin-token` header — only for `/api/admin/run-cron/{name}`. Fail-closed (500 if secret not set). Compared via `timingSafeCompare` (`src/lib/auth.ts`).
 - **Telegram webhook secrets**: `/api/telegram/{bot}/[secret]` path param compared via `timingSafeCompare` to prevent timing oracles.
 - **Draft preview links**: `src/lib/draft-preview.ts` — 32-byte hex tokens, SHA-256 stored in D1, 24h TTL.
-- **Secrets files**: `.dev.vars` / `.production.vars` are gitignored — never commit. Production secrets via `wrangler secret put`.
+- **Secrets files**: `.dev.vars` (local dev + `astro build` runtime emulation) and `.production.vars` (production values) are gitignored — never commit. `pnpm run deploy` = `wrangler deploy --secrets-file .production.vars`, which uploads those secrets **alongside the code on every deploy** (dotenv format; omitted keys are preserved, never deleted). So keep `.production.vars` complete and current — a deploy overwrites live secrets with its contents. `wrangler deploy` never auto-loads any vars file; the `Using secrets defined in .dev.vars` line printed during `astro build` is **local emulation only** and does not reach production. One-off secret changes can still use `wrangler secret put`.
 </important>
 
 <important if="you are implementing a new feature">

--- a/docs/notes/HOW_TO.md
+++ b/docs/notes/HOW_TO.md
@@ -29,7 +29,7 @@ Cel biznesowy: sprzedawcy dzwonia do firm bez stron www, oferuja gotowa wizytowk
 | Geokodowanie | Nominatim (OpenStreetMap) |
 | Scraping firm | SerpAPI (Google Maps) |
 | Powiadomienia | Telegram Bot API |
-| Deploy | wrangler deploy |
+| Deploy | pnpm run deploy (`wrangler deploy --secrets-file .production.vars`) |
 
 ---
 
@@ -311,8 +311,10 @@ Endpoint: `POST /api/contact` -- przyjmuje numer telefonu z formularza na stroni
 
 **Deploy:**
 ```bash
-pnpm run build && pnpm wrangler deploy
+pnpm run build && pnpm run deploy   # deploy = `wrangler deploy --secrets-file .production.vars`
 ```
+
+> `pnpm run deploy` przesyła sekrety z `.production.vars` razem z kodem (format dotenv; pominięte klucze są zachowywane, nigdy nie kasowane). Uruchamiaj `pnpm run deploy`, **nie** `pnpm wrangler deploy` — bezpośrednie wywołanie pomija flagę `--secrets-file`. Wymaga Node ≥22.15 (`nvm use`).
 
 **Sekrety (`.production.vars`, nigdy w repo):**
 
@@ -340,7 +342,7 @@ pnpm run build && pnpm wrangler deploy
 | Raporty Telegram | Po scrape'ie | -- |
 | Dodanie sprzedawcy | -- | INSERT do D1 + link TG |
 | Obdzwanianie leadow | -- | Sprzedawca przez panel |
-| Deploy | -- | `pnpm wrangler deploy` |
+| Deploy | -- | `pnpm run deploy` |
 | Monitoring | Podstawowy (CF Dashboard) | Manualna kontrola MVP |
 
 ---
@@ -351,7 +353,7 @@ pnpm run build && pnpm wrangler deploy
 
 - Konfiguracja: `wrangler.jsonc`, sekrety, domena
 - Jednorazowy seed TERYT (`npx tsx seed/parse-simc.ts`)
-- Deploy (`pnpm wrangler deploy`)
+- Deploy (`pnpm run deploy`)
 - Dodawanie sellerow (INSERT do D1 + generowanie link TG)
 - Monitoring logow (`pnpm wrangler tail`)
 - Migracje D1 (`wrangler d1 execute`)
@@ -534,7 +536,7 @@ wrangler.jsonc           # konfiguracja CF Worker
 pnpm dev              # Astro dev server (lokalnie)
 pnpm build            # build SSR do dist/
 pnpm preview          # wrangler dev (lokalna emulacja CF)
-pnpm deploy           # wrangler deploy (produkcja)
+pnpm run deploy       # wrangler deploy --secrets-file .production.vars (produkcja; Node >=22.15)
 pnpm db:migrate       # migracje D1
 
 # Cron trigger (lokalne testowanie):

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"seed:into-d1": "tsx scripts/parse-simc.ts",
 		"db:migrate:fresh": "rm -rf .wrangler/state/v3/d1 .wrangler/state/v3/r2 && pnpm db:migrate",
 		"seed": "pnpm db:migrate:fresh && pnpm tsx scripts/seed-local-test.ts",
-		"deploy": "wrangler deploy",
+		"deploy": "wrangler deploy --secrets-file .production.vars",
 		"audit:prod": "pnpm audit --prod",
 		"deps": "taze",
 		"deps:major": "taze major",


### PR DESCRIPTION
## What

`pnpm run deploy` is now `wrangler deploy --secrets-file .production.vars`. A production deploy uploads secrets from `.production.vars` alongside the code in a single operation (dotenv format; omitted keys are preserved, never deleted).

## Why

Previously nothing auto-loaded `.production.vars` — production secrets had to be set out of band via `wrangler secret put`, and the `.dev.vars` line printed during `astro build` (local runtime emulation) caused confusion about which secrets production uses. Wiring `--secrets-file` makes "deploy to production uses production secrets" explicit and single-step.

## Behavior notes

- `.production.vars` is now load-bearing on every deploy — keep it complete/current.
- Use `pnpm run deploy`, **not** `pnpm wrangler deploy` (the latter bypasses `--secrets-file`).
- Verified with `wrangler deploy --dry-run --secrets-file .production.vars`: the file parses (secrets appear as `(hidden)` bindings), no upload performed.

## Docs

- `.claude/CLAUDE.md`: new secrets/deploy flow; Node ≥22.15 requirement; `.dev.vars`-is-emulation-only clarification.
- `docs/notes/HOW_TO.md`: replaced stale `pnpm wrangler deploy` with `pnpm run deploy`; documented the secrets-upload behavior.
- Left `docs/design/done/*` as historical record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)